### PR TITLE
Merge TimingPrecedence and AssignmentPrecedence to Constraint

### DIFF
--- a/docs/source/api/pyjobshop.rst
+++ b/docs/source/api/pyjobshop.rst
@@ -24,7 +24,7 @@ PyJobShop
     .. autoclass:: Job
        :members:
 
-    .. autoclass:: Precedence
+    .. autoclass:: Constraint
        :members:
 
     .. autoclass:: Objective

--- a/docs/source/api/pyjobshop.rst
+++ b/docs/source/api/pyjobshop.rst
@@ -24,11 +24,9 @@ PyJobShop
     .. autoclass:: Job
        :members:
 
-    .. autoclass:: Constraint
-       :members:
+    .. autoenum:: Constraint
 
-    .. autoclass:: Objective
-       :members:	   
+    .. autoenum:: Objective
 
 .. automodule:: pyjobshop.Solution
 

--- a/docs/source/api/pyjobshop.rst
+++ b/docs/source/api/pyjobshop.rst
@@ -24,10 +24,7 @@ PyJobShop
     .. autoclass:: Job
        :members:
 
-    .. autoclass:: TimingPrecedence
-       :members:
-
-    .. autoclass:: AssignmentPrecedence
+    .. autoclass:: Precedence
        :members:
 
     .. autoclass:: Objective

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,7 @@ extensions = [
     "sphinx_immaterial",
     "nbsphinx",
     "numpydoc",
+    "enum_tools.autoenum",
 ]
 
 templates_path = ["_templates"]

--- a/examples/simple_example.ipynb
+++ b/examples/simple_example.ipynb
@@ -158,7 +158,7 @@
     "    for idx in range(len(job_data) - 1):\n",
     "        first = operations[(job_idx, idx)]\n",
     "        second = operations[(job_idx, idx + 1)]\n",
-    "        m.add_precedence(first, second)"
+    "        m.add_constraint(first, second)"
    ]
   },
   {

--- a/examples/simple_example.ipynb
+++ b/examples/simple_example.ipynb
@@ -158,7 +158,7 @@
     "    for idx in range(len(job_data) - 1):\n",
     "        first = operations[(job_idx, idx)]\n",
     "        second = operations[(job_idx, idx + 1)]\n",
-    "        m.add_timing_precedence(first, second)"
+    "        m.add_precedence(first, second)"
    ]
   },
   {

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -6,13 +6,12 @@ from docplex.cp.solution import CpoSolveResult
 
 from .cp import default_model, result2solution
 from .ProblemData import (
-    AssignmentPrecedence,
     Job,
     Machine,
     Objective,
     Operation,
+    Precedence,
     ProblemData,
-    TimingPrecedence,
 )
 from .Result import Result
 
@@ -28,11 +27,8 @@ class Model:
         self._operations = []
         self._job2ops: dict[int, list[int]] = defaultdict(list)
         self._processing_times: dict[tuple[int, int], int] = {}
-        self._timing_precedences: dict[
-            tuple[int, int], list[tuple[TimingPrecedence, int]]
-        ] = defaultdict(list)
-        self._assignment_precedences: dict[
-            tuple[int, int], list[AssignmentPrecedence]
+        self._precedences: dict[
+            tuple[int, int], list[tuple[Precedence, int]]
         ] = defaultdict(list)
         self._setup_times: dict[tuple[int, int, int], int] = {}
         self._process_plans: list[list[list[int]]] = []
@@ -80,8 +76,7 @@ class Model:
             operations=self.operations,
             job2ops=job2ops,
             processing_times=self._processing_times,
-            timing_precedences=self._timing_precedences,
-            assignment_precedences=self._assignment_precedences,
+            precedences=self._precedences,
             setup_times=setup_times,
             process_plans=self._process_plans,
             planning_horizon=self._planning_horizon,
@@ -246,15 +241,15 @@ class Model:
         op_idx = self._id2op[id(operation)]
         self._processing_times[machine_idx, op_idx] = duration
 
-    def add_timing_precedence(
+    def add_precedence(
         self,
         operation1: Operation,
         operation2: Operation,
-        constraint: TimingPrecedence = TimingPrecedence.END_BEFORE_START,
+        constraint: Precedence = Precedence.END_BEFORE_START,
         delay: int = 0,
     ):
         """
-        Adds a timing precedence constraint between two operations.
+        Adds a precedence constraint between two operations.
 
         Parameters
         ----------
@@ -272,31 +267,7 @@ class Model:
         """
         op1 = self._id2op[id(operation1)]
         op2 = self._id2op[id(operation2)]
-        self._timing_precedences[op1, op2].append((constraint, delay))
-
-    def add_assignment_precedence(
-        self,
-        operation1: Operation,
-        operation2: Operation,
-        assignment_precedence: AssignmentPrecedence,
-    ):
-        """
-        Adds an assignment precedence constraints between two operations.
-
-        Parameters
-        ----------
-        operation1
-            First operation.
-        operation2
-            Second operation.
-        assignment_precedence
-            Assignment precedence relation between the first and the second
-            operation.
-
-        """
-        op1 = self._id2op[id(operation1)]
-        op2 = self._id2op[id(operation2)]
-        self._assignment_precedences[op1, op2].append(assignment_precedence)
+        self._precedences[op1, op2].append((constraint, delay))
 
     def add_setup_time(
         self,

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -28,7 +28,7 @@ class Model:
         self._job2ops: dict[int, list[int]] = defaultdict(list)
         self._processing_times: dict[tuple[int, int], int] = {}
         self._constraints: dict[
-            tuple[int, int], list[tuple[Constraint, dict]]
+            tuple[int, int], list[Constraint]
         ] = defaultdict(list)
         self._setup_times: dict[tuple[int, int, int], int] = {}
         self._process_plans: list[list[list[int]]] = []
@@ -257,8 +257,7 @@ class Model:
         self,
         operation1: Operation,
         operation2: Operation,
-        constraint: Constraint = Constraint.END_BEFORE_START,
-        **kwargs,
+        constraint: Constraint,
     ):
         """
         Adds a precedence constraint between two operations.
@@ -270,15 +269,11 @@ class Model:
         operation2
             Second operation.
         constraint
-            Constraint between the first and the second operation. Default
-            is ``END_BEFORE_START``, meaning that the first operation must
-            end before the second operation starts.
-        kwargs
-            Additional keyword arguments for the constraint.
+            Constraint between the first and the second operation.
         """
         op1 = self._id2op[id(operation1)]
         op2 = self._id2op[id(operation2)]
-        self._constraints[op1, op2].append((constraint, kwargs))
+        self._constraints[op1, op2].append(constraint)
 
     def add_setup_time(
         self,

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -255,8 +255,8 @@ class Model:
 
     def add_constraint(
         self,
-        operation1: Operation,
-        operation2: Operation,
+        first: Operation,
+        second: Operation,
         constraint: Constraint,
     ):
         """
@@ -264,15 +264,15 @@ class Model:
 
         Parameters
         ----------
-        operation1
+        first
             First operation.
-        operation2
+        second
             Second operation.
         constraint
             Constraint between the first and the second operation.
         """
-        op1 = self._id2op[id(operation1)]
-        op2 = self._id2op[id(operation2)]
+        op1 = self._id2op[id(first)]
+        op2 = self._id2op[id(second)]
         self._constraints[op1, op2].append(constraint)
 
     def add_setup_time(

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -62,6 +62,9 @@ class Model:
 
     @property
     def objective(self) -> Objective:
+        """
+        Returns the objective function to be minimized in this model.
+        """
         return self._objective
 
     def data(self) -> ProblemData:

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -22,9 +22,9 @@ class Model:
     """
 
     def __init__(self):
-        self._jobs = []
-        self._machines = []
-        self._operations = []
+        self._jobs: list[Job] = []
+        self._machines: list[Machine] = []
+        self._operations: list[Operation] = []
         self._job2ops: dict[int, list[int]] = defaultdict(list)
         self._processing_times: dict[tuple[int, int], int] = {}
         self._precedences: dict[

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -41,14 +41,23 @@ class Model:
 
     @property
     def jobs(self) -> list[Job]:
+        """
+        Returns the list of jobs in the model.
+        """
         return self._jobs
 
     @property
     def machines(self) -> list[Machine]:
+        """
+        Returns the list of machines in the model.
+        """
         return self._machines
 
     @property
     def operations(self) -> list[Operation]:
+        """
+        Returns the list of operations in the model.
+        """
         return self._operations
 
     @property

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -287,7 +287,8 @@ class ProblemData:
         Processing times of operations on machines. First index is the machine
         index, second index is the operation index.
     precedences
-        Dict indexed by operation pairs with list of precedence constraints and delays.
+        Dict indexed by operation pairs with list of precedence constraints and
+        delays.
     setup_times
         Sequence-dependent setup times between operations on a given machine.
         The first dimension of the array is indexed by the machine index. The

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -2,6 +2,7 @@ import bisect
 from enum import Enum
 from typing import Iterable, Optional
 
+import enum_tools.documentation
 import numpy as np
 
 _CONSTRAINTS_TYPE = dict[tuple[int, int], list[tuple["Constraint", dict]]]
@@ -210,71 +211,76 @@ class Operation:
         return self._name
 
 
+@enum_tools.documentation.document_enum
 class Objective(str, Enum):
     """
     Choices for objective functions (to be minimized).
-
-    - makespan:               Maximum completion time of all jobs.
-    - tardy_jobs:             Number of tardy jobs.
-    - total_completion_time:  Sum of completion times of all jobs.
-    - total_tardiness:        Sum of tardiness of all jobs.
-
     """
 
+    #: Minimize the maximum completion time of all jobs.
     MAKESPAN = "makespan"
+
+    #: Minimizes the number of jobs whose completion times exceed the due date.
     TARDY_JOBS = "tardy_jobs"
+
+    #: Minimize the sum of job completion times.
     TOTAL_COMPLETION_TIME = "total_completion_time"
+
+    #: Minimize the sum of job tardiness.
     TOTAL_TARDINESS = "total_tardiness"
 
 
+@enum_tools.documentation.document_enum
 class Constraint(str, Enum):
     """
     Operation constraints between two operations :math:`i` and :math:`j`.
     We distinguish between timing precedence constraints and assignment
     constraints.
 
-    Timing precedence constraints
-    -----------------------------
-
     Timing precedence constraints are constraints on the start and finish
     times of operations. Let :math:`s(i)` and :math:`f(i)` denote the start
     and finish times of operation :math:`i`. The following precedence
     constraints are supported:
 
-    * START_AT_START:        :math:`s(i) == s(j)`
-    * START_AT_END:          :math:`s(i) == f(j)`
-    * START_BEFORE_START:    :math:`s(i) <= s(j)`
-    * START_BEFORE_END:      :math:`s(i) <= f(j)`
-    * END_AT_START:          :math:`f(i) == s(j)`
-    * END_AT_END:            :math:`f(i) == f(j)`
-    * END_BEFORE_START:      :math:`f(i) <= s(j)`
-    * END_BEFORE_END:        :math:`f(i) <= f(j)`
-
     Timing precedence constraints can combined a delay :math:`d`, which is
     added to the left-hand side of the constraint. For example, the constraint
     `start_at_start` with delay :math:`d` is then :math:`s(i) + d == s(j)`.
 
-    Assignment constraints
-    ----------------------
-
     Assignment constraints are constraints on the assignment of operations to
-    machines. The following assignment constraints are supported:
-
-    * PREVIOUS:         sequence :math:`i` previous to :math:`j`.
-    * SAME_UNIT:        assign :math:`i` and :math:`j` on the same unit.
-    * DIFFERENT_UNIT:   assign :math:`i` and :math:`j` on different units.
+    machines.
     """
 
+    #: Start :math:`i` at start :math:`j`
     START_AT_START = "start_at_start"
+
+    #: Start :math:`i` at end :math:`j`
     START_AT_END = "start_at_end"
+
+    #: Start :math:`i` before start :math:`j`
     START_BEFORE_START = "start_before_start"
+
+    #: Start :math:`i` before end :math:`j`
     START_BEFORE_END = "start_before_end"
+
+    #: End :math:`i` at start :math:`j`
     END_AT_START = "end_at_start"
+
+    #: End :math:`i` at end :math:`j`
     END_AT_END = "end_at_end"
+
+    #: End :math:`i` before start :math:`j`
     END_BEFORE_START = "end_before_start"
+
+    #: End :math:`i` before end :math:`j`
     END_BEFORE_END = "end_before_end"
+
+    #: Sequence :math:`i` previous to :math:`j` (if on the same machine)
     PREVIOUS = "previous"
+
+    #: Assign :math:`i` and :math:`j` to the same machine
     SAME_UNIT = "same_unit"
+
+    #: Assign :math:`i` and :math:`j` to different machine
     DIFFERENT_UNIT = "different_unit"
 
 
@@ -436,7 +442,7 @@ class ProblemData:
 
         Returns
         -------
-        dict[tuple[int, int], list[tuple[Precedence, dict]]]
+        dict[tuple[int, int], list[tuple[Constraint, dict]]]
             The dictionary is indexed by operation pairs with a list of tuples
             that contain the constraint type and additional dictionary data.
         """

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -5,7 +5,7 @@ from typing import Iterable, Optional
 import enum_tools.documentation
 import numpy as np
 
-_CONSTRAINTS_TYPE = dict[tuple[int, int], list[tuple["Constraint", dict]]]
+_CONSTRAINTS_TYPE = dict[tuple[int, int], list["Constraint"]]
 
 
 class Job:
@@ -234,53 +234,39 @@ class Objective(str, Enum):
 class Constraint(str, Enum):
     """
     Operation constraints between two operations :math:`i` and :math:`j`.
-    We distinguish between timing precedence constraints and assignment
-    constraints.
-
-    Timing precedence constraints are constraints on the start and finish
-    times of operations. Let :math:`s(i)` and :math:`f(i)` denote the start
-    and finish times of operation :math:`i`. The following precedence
-    constraints are supported:
-
-    Timing precedence constraints can combined a delay :math:`d`, which is
-    added to the left-hand side of the constraint. For example, the constraint
-    `start_at_start` with delay :math:`d` is then :math:`s(i) + d == s(j)`.
-
-    Assignment constraints are constraints on the assignment of operations to
-    machines.
     """
 
-    #: Start :math:`i` at start :math:`j`
+    #: Operation :math:`i` must start when operation :math:`j` starts.
     START_AT_START = "start_at_start"
 
-    #: Start :math:`i` at end :math:`j`
+    #: Operation :math:`i` must at start when operation :math:`j` ends.
     START_AT_END = "start_at_end"
 
-    #: Start :math:`i` before start :math:`j`
+    #: Operation :math:`i` must start before operation :math:`j` starts.
     START_BEFORE_START = "start_before_start"
 
-    #: Start :math:`i` before end :math:`j`
+    #: Operation :math:`i` must start before operation :math:`j` ends.
     START_BEFORE_END = "start_before_end"
 
-    #: End :math:`i` at start :math:`j`
+    #: Operation :math:`i` must end when operation :math:`j` starts.
     END_AT_START = "end_at_start"
 
-    #: End :math:`i` at end :math:`j`
+    #: Operation :math:`i` must end when operation :math:`j` ends.
     END_AT_END = "end_at_end"
 
-    #: End :math:`i` before start :math:`j`
+    #: Operation :math:`i` must end before operation :math:`j` starts.
     END_BEFORE_START = "end_before_start"
 
-    #: End :math:`i` before end :math:`j`
+    #: Operation :math:`i` must end before operation :math:`j` ends.
     END_BEFORE_END = "end_before_end"
 
-    #: Sequence :math:`i` previous to :math:`j` (if on the same machine)
+    #: Sequence :math:`i` right before :math:`j` (if assigned to same machine).
     PREVIOUS = "previous"
 
-    #: Assign :math:`i` and :math:`j` to the same machine
+    #: Assign operations :math:`i` and :math:`j` to the same machine.
     SAME_UNIT = "same_unit"
 
-    #: Assign :math:`i` and :math:`j` to different machine
+    #: Assign operations :math:`i` and :math:`j` to different machine.
     DIFFERENT_UNIT = "different_unit"
 
 
@@ -303,8 +289,7 @@ class ProblemData:
         Processing times of operations on machines. First index is the machine
         index, second index is the operation index.
     constraints
-        Dict indexed by operation pairs with list of precedence constraints and
-        delays.
+        Dict indexed by operation pairs with a list of constraints as values.
     setup_times
         Sequence-dependent setup times between operations on a given machine.
         The first dimension of the array is indexed by the machine index. The
@@ -442,9 +427,9 @@ class ProblemData:
 
         Returns
         -------
-        dict[tuple[int, int], list[tuple[Constraint, dict]]]
-            The dictionary is indexed by operation pairs with a list of tuples
-            that contain the constraint type and additional dictionary data.
+        dict[tuple[int, int], list[Constraint]]
+            The dictionary is indexed by operation pairs with a list of
+            constraints.
         """
         return self._constraints
 

--- a/pyjobshop/__init__.py
+++ b/pyjobshop/__init__.py
@@ -5,5 +5,4 @@ from .plot import plot as plot
 from .ProblemData import Job as Job
 from .ProblemData import Machine as Machine
 from .ProblemData import Operation as Operation
-from .ProblemData import Precedence as Precedence
 from .ProblemData import ProblemData as ProblemData

--- a/pyjobshop/__init__.py
+++ b/pyjobshop/__init__.py
@@ -2,6 +2,7 @@ from .cp import default_model as default_model
 from .cp import result2solution as result2solution
 from .Model import Model as Model
 from .plot import plot as plot
+from .ProblemData import Constraint as Constraint
 from .ProblemData import Job as Job
 from .ProblemData import Machine as Machine
 from .ProblemData import Operation as Operation

--- a/pyjobshop/__init__.py
+++ b/pyjobshop/__init__.py
@@ -1,10 +1,9 @@
-from .cp import default_model, result2solution
-from .Model import Model
-from .plot import plot
-from .ProblemData import (
-    Job,
-    Machine,
-    Operation,
-    Precedence,
-    ProblemData,
-)
+from .cp import default_model as default_model
+from .cp import result2solution as result2solution
+from .Model import Model as Model
+from .plot import plot as plot
+from .ProblemData import Job as Job
+from .ProblemData import Machine as Machine
+from .ProblemData import Operation as Operation
+from .ProblemData import Precedence as Precedence
+from .ProblemData import ProblemData as ProblemData

--- a/pyjobshop/__init__.py
+++ b/pyjobshop/__init__.py
@@ -2,10 +2,9 @@ from .cp import default_model, result2solution
 from .Model import Model
 from .plot import plot
 from .ProblemData import (
-    AssignmentPrecedence,
     Job,
     Machine,
     Operation,
+    Precedence,
     ProblemData,
-    TimingPrecedence,
 )

--- a/pyjobshop/cp/__init__.py
+++ b/pyjobshop/cp/__init__.py
@@ -1,2 +1,2 @@
-from .default_model import default_model
-from .result2solution import result2solution
+from .default_model import default_model as default_model
+from .result2solution import result2solution as result2solution

--- a/pyjobshop/cp/constraints.py
+++ b/pyjobshop/cp/constraints.py
@@ -227,25 +227,23 @@ def operation_graph_constraints(
         op1 = op_vars[idx1]
         op2 = op_vars[idx2]
 
-        for constraint_type, constraint_data in precedences:
-            delay = constraint_data.get("delay", 0)
-
-            if constraint_type == "start_at_start":
-                expr = m.start_at_start(op1, op2, delay)
-            elif constraint_type == "start_at_end":
-                expr = m.start_at_end(op1, op2, delay)
-            elif constraint_type == "start_before_start":
-                expr = m.start_before_start(op1, op2, delay)
-            elif constraint_type == "start_before_end":
-                expr = m.start_before_end(op1, op2, delay)
-            elif constraint_type == "end_at_start":
-                expr = m.end_at_start(op1, op2, delay)
-            elif constraint_type == "end_at_end":
-                expr = m.end_at_end(op1, op2, delay)
-            elif constraint_type == "end_before_start":
-                expr = m.end_before_start(op1, op2, delay)
-            elif constraint_type == "end_before_end":
-                expr = m.end_before_end(op1, op2, delay)
+        for constraint in precedences:
+            if constraint == "start_at_start":
+                expr = m.start_at_start(op1, op2)
+            elif constraint == "start_at_end":
+                expr = m.start_at_end(op1, op2)
+            elif constraint == "start_before_start":
+                expr = m.start_before_start(op1, op2)
+            elif constraint == "start_before_end":
+                expr = m.start_before_end(op1, op2)
+            elif constraint == "end_at_start":
+                expr = m.end_at_start(op1, op2)
+            elif constraint == "end_at_end":
+                expr = m.end_at_end(op1, op2)
+            elif constraint == "end_before_start":
+                expr = m.end_before_start(op1, op2)
+            elif constraint == "end_before_end":
+                expr = m.end_before_end(op1, op2)
 
     for machine, ops in enumerate(data.machine2ops):
         seq_var = seq_vars[machine]
@@ -257,12 +255,12 @@ def operation_graph_constraints(
             var1 = task_vars[op1, machine]
             var2 = task_vars[op2, machine]
 
-            for constraint_type, _ in data.constraints[op1, op2]:
-                if constraint_type == "previous":
+            for constraint in data.constraints[op1, op2]:
+                if constraint == "previous":
                     expr = m.previous(seq_var, var1, var2)
-                elif constraint_type == "same_unit":
+                elif constraint == "same_unit":
                     expr = m.presence_of(var1) == m.presence_of(var2)
-                elif constraint_type == "different_unit":
+                elif constraint == "different_unit":
                     expr = m.presence_of(var1) != m.presence_of(var2)
 
                 constraints.append(expr)

--- a/pyjobshop/cp/constraints.py
+++ b/pyjobshop/cp/constraints.py
@@ -223,11 +223,11 @@ def operation_graph_constraints(
 ) -> list[CpoExpr]:
     constraints = []
 
-    for (idx1, idx2), precedences in data.constraints.items():
+    for (idx1, idx2), op_constraints in data.constraints.items():
         op1 = op_vars[idx1]
         op2 = op_vars[idx2]
 
-        for constraint in precedences:
+        for constraint in op_constraints:
             if constraint == "start_at_start":
                 expr = m.start_at_start(op1, op2)
             elif constraint == "start_at_end":
@@ -244,7 +244,12 @@ def operation_graph_constraints(
                 expr = m.end_before_start(op1, op2)
             elif constraint == "end_before_end":
                 expr = m.end_before_end(op1, op2)
+            else:
+                continue
 
+            constraints.append(expr)
+
+    # Separately handle assignment related constraints for efficiency.
     for machine, ops in enumerate(data.machine2ops):
         seq_var = seq_vars[machine]
 

--- a/pyjobshop/cp/default_model.py
+++ b/pyjobshop/cp/default_model.py
@@ -4,7 +4,6 @@ from pyjobshop.ProblemData import ProblemData
 
 from .constraints import (
     alternative_constraints,
-    assignment_precedence_constraints,
     job_data_constraints,
     job_operation_constraints,
     machine_data_constraints,
@@ -12,8 +11,8 @@ from .constraints import (
     operation_constraints,
     optional_operation_selection_constraints,
     planning_horizon_constraints,
+    precedence_constraints,
     processing_time_constraints,
-    timing_precedence_constraints,
 )
 from .objectives import (
     makespan,
@@ -65,9 +64,6 @@ def default_model(data: ProblemData) -> CpoModel:
     model.add(machine_data_constraints(model, data, task_vars))
     model.add(job_operation_constraints(model, data, job_vars, op_vars))
     model.add(operation_constraints(model, data, op_vars))
-    model.add(
-        assignment_precedence_constraints(model, data, task_vars, seq_vars)
-    )
     model.add(alternative_constraints(model, data, op_vars, task_vars))
     model.add(no_overlap_and_setup_time_constraints(model, data, seq_vars))
     model.add(optional_operation_selection_constraints(model, data, op_vars))
@@ -75,6 +71,8 @@ def default_model(data: ProblemData) -> CpoModel:
         planning_horizon_constraints(model, data, job_vars, task_vars, op_vars)
     )
     model.add(processing_time_constraints(model, data, task_vars))
-    model.add(timing_precedence_constraints(model, data, op_vars))
+    model.add(
+        precedence_constraints(model, data, op_vars, task_vars, seq_vars)
+    )
 
     return model

--- a/pyjobshop/cp/default_model.py
+++ b/pyjobshop/cp/default_model.py
@@ -9,9 +9,9 @@ from .constraints import (
     machine_data_constraints,
     no_overlap_and_setup_time_constraints,
     operation_constraints,
+    operation_graph_constraints,
     optional_operation_selection_constraints,
     planning_horizon_constraints,
-    precedence_constraints,
     processing_time_constraints,
 )
 from .objectives import (
@@ -72,7 +72,7 @@ def default_model(data: ProblemData) -> CpoModel:
     )
     model.add(processing_time_constraints(model, data, task_vars))
     model.add(
-        precedence_constraints(model, data, op_vars, task_vars, seq_vars)
+        operation_graph_constraints(model, data, op_vars, task_vars, seq_vars)
     )
 
     return model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "poetry.core.masonry.api"
 python = ">=3.9, <3.11"
 numpy = "^1.24.2"
 matplotlib = "^3.7.1"
-docplex = { version = "^2.25.236", optional = true }
+docplex = "^2.25.236"
 cplex = { version = "22.1.1.0", optional = true }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,10 +81,6 @@ ignore = [
 ]
 
 
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F401"] # ignore unused module imports
-
-
 [tool.pytest.ini_options]
 addopts = "--cov=. --cov-report=xml"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ numpy = "^1.24.2"
 matplotlib = "^3.7.1"
 docplex = "^2.25.236"
 cplex = { version = "22.1.1.0", optional = true }
+enum-tools = "^0.11.0"
 
 
 [tool.poetry.extras]
@@ -43,7 +44,7 @@ sphinx = "^7.2.6"
 nbsphinx = "^0.9.3"
 numpydoc = "^1.6.0"
 sphinx-immaterial = "^0.11.10"
-
+enum-tools = { extras = ["sphinx"], version = "^0.11.0" }
 
 [tool.poetry.group.examples.dependencies]
 jupyterlab = "^4.0.12"

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -23,8 +23,8 @@ def test_model_to_data():
     model.add_processing_time(mach1, op1, 1)
     model.add_processing_time(mach2, op2, 2)
 
-    model.add_constraint(op1, op2, Constraint.END_BEFORE_START, delay=10)
-    model.add_constraint(op1, op2, Constraint.START_BEFORE_END, delay=10)
+    model.add_constraint(op1, op2, Constraint.END_BEFORE_START)
+    model.add_constraint(op1, op2, Constraint.START_BEFORE_END)
     model.add_constraint(op2, op1, Constraint.SAME_UNIT)
     model.add_constraint(op2, op1, Constraint.PREVIOUS)
 
@@ -46,12 +46,12 @@ def test_model_to_data():
         data.constraints,
         {
             (0, 1): [
-                (Constraint.END_BEFORE_START, {"delay": 10}),
-                (Constraint.START_BEFORE_END, {"delay": 10}),
+                Constraint.END_BEFORE_START,
+                Constraint.START_BEFORE_END,
             ],
             (1, 0): [
-                (Constraint.SAME_UNIT, {}),
-                (Constraint.PREVIOUS, {}),
+                Constraint.SAME_UNIT,
+                Constraint.PREVIOUS,
             ],
         },
     )

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -1,7 +1,7 @@
 from numpy.testing import assert_equal
 
 from pyjobshop.Model import Model
-from pyjobshop.ProblemData import Objective, Precedence
+from pyjobshop.ProblemData import Constraint, Objective
 from pyjobshop.Solution import Solution, Task
 
 MAX_VALUE = 2**25
@@ -23,10 +23,10 @@ def test_model_to_data():
     model.add_processing_time(mach1, op1, 1)
     model.add_processing_time(mach2, op2, 2)
 
-    model.add_precedence(op1, op2, Precedence.END_BEFORE_START, 10)
-    model.add_precedence(op1, op2, Precedence.START_BEFORE_END, 10)
-    model.add_precedence(op2, op1, Precedence.SAME_UNIT)
-    model.add_precedence(op2, op1, Precedence.PREVIOUS)
+    model.add_constraint(op1, op2, Constraint.END_BEFORE_START, delay=10)
+    model.add_constraint(op1, op2, Constraint.START_BEFORE_END, delay=10)
+    model.add_constraint(op2, op1, Constraint.SAME_UNIT)
+    model.add_constraint(op2, op1, Constraint.PREVIOUS)
 
     model.add_setup_time(mach1, op1, op2, 3)
     model.add_setup_time(mach2, op1, op2, 4)
@@ -43,15 +43,15 @@ def test_model_to_data():
     assert_equal(data.job2ops, [[0, 1]])
     assert_equal(data.processing_times, {(0, 0): 1, (1, 1): 2})
     assert_equal(
-        data.precedences,
+        data.constraints,
         {
             (0, 1): [
-                (Precedence.END_BEFORE_START, 10),
-                (Precedence.START_BEFORE_END, 10),
+                (Constraint.END_BEFORE_START, {"delay": 10}),
+                (Constraint.START_BEFORE_END, {"delay": 10}),
             ],
             (1, 0): [
-                (Precedence.SAME_UNIT, 0),
-                (Precedence.PREVIOUS, 0),
+                (Constraint.SAME_UNIT, {}),
+                (Constraint.PREVIOUS, {}),
             ],
         },
     )
@@ -78,7 +78,7 @@ def test_model_to_data_default_values():
     assert_equal(data.operations, [operation])
     assert_equal(data.job2ops, [[0]])
     assert_equal(data.processing_times, {})
-    assert_equal(data.precedences, {})
+    assert_equal(data.constraints, {})
     assert_equal(data.setup_times, [[[0]]])
     assert_equal(data.process_plans, [])
     assert_equal(data.planning_horizon, None)

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -1,11 +1,7 @@
 from numpy.testing import assert_equal
 
 from pyjobshop.Model import Model
-from pyjobshop.ProblemData import (
-    AssignmentPrecedence,
-    Objective,
-    TimingPrecedence,
-)
+from pyjobshop.ProblemData import Objective, Precedence
 from pyjobshop.Solution import Solution, Task
 
 MAX_VALUE = 2**25
@@ -27,15 +23,10 @@ def test_model_to_data():
     model.add_processing_time(mach1, op1, 1)
     model.add_processing_time(mach2, op2, 2)
 
-    model.add_timing_precedence(
-        op1, op2, TimingPrecedence.END_BEFORE_START, 10
-    )
-    model.add_timing_precedence(
-        op1, op2, TimingPrecedence.START_BEFORE_END, 10
-    )
-
-    model.add_assignment_precedence(op2, op1, AssignmentPrecedence.SAME_UNIT)
-    model.add_assignment_precedence(op2, op1, AssignmentPrecedence.PREVIOUS)
+    model.add_precedence(op1, op2, Precedence.END_BEFORE_START, 10)
+    model.add_precedence(op1, op2, Precedence.START_BEFORE_END, 10)
+    model.add_precedence(op2, op1, Precedence.SAME_UNIT)
+    model.add_precedence(op2, op1, Precedence.PREVIOUS)
 
     model.add_setup_time(mach1, op1, op2, 3)
     model.add_setup_time(mach2, op1, op2, 4)
@@ -52,21 +43,16 @@ def test_model_to_data():
     assert_equal(data.job2ops, [[0, 1]])
     assert_equal(data.processing_times, {(0, 0): 1, (1, 1): 2})
     assert_equal(
-        data.timing_precedences,
+        data.precedences,
         {
             (0, 1): [
-                (TimingPrecedence.END_BEFORE_START, 10),
-                (TimingPrecedence.START_BEFORE_END, 10),
-            ]
-        },
-    )
-    assert_equal(
-        data.assignment_precedences,
-        {
+                (Precedence.END_BEFORE_START, 10),
+                (Precedence.START_BEFORE_END, 10),
+            ],
             (1, 0): [
-                AssignmentPrecedence.SAME_UNIT,
-                AssignmentPrecedence.PREVIOUS,
-            ]
+                (Precedence.SAME_UNIT, 0),
+                (Precedence.PREVIOUS, 0),
+            ],
         },
     )
     assert_equal(data.setup_times, [[[0, 3], [0, 0]], [[0, 4], [0, 0]]])
@@ -92,8 +78,7 @@ def test_model_to_data_default_values():
     assert_equal(data.operations, [operation])
     assert_equal(data.job2ops, [[0]])
     assert_equal(data.processing_times, {})
-    assert_equal(data.timing_precedences, {})
-    assert_equal(data.assignment_precedences, {})
+    assert_equal(data.precedences, {})
     assert_equal(data.setup_times, [[[0]]])
     assert_equal(data.process_plans, [])
     assert_equal(data.planning_horizon, None)

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -1,4 +1,3 @@
-import random
 from typing import Optional
 
 import numpy as np
@@ -963,41 +962,6 @@ def test_total_weighted_tardiness():
 
 
 # --- Small classical examples. ---
-def test_blocking_flowshop():
-    """
-    Blocking flowshop example.
-    """
-    random.seed(42)
-
-    NUM_JOBS = 5
-    NUM_MACHINES = 5
-
-    model = Model()
-    jobs = [model.add_job() for _ in range(NUM_JOBS)]
-    machines = [model.add_machine() for _ in range(NUM_MACHINES)]
-
-    for job in jobs:
-        # One operation per job and machine pair.
-        operations = [
-            model.add_operation(job=job, fixed_duration=False)
-            for _ in range(NUM_MACHINES)
-        ]
-
-        for machine, op in zip(machines, operations):
-            model.add_processing_time(machine, op, random.randint(1, 10))
-
-        # Create precedence constraints between operations.
-        for idx in range(len(operations) - 1):
-            model.add_precedence(
-                operations[idx],
-                operations[idx + 1],
-                Precedence.END_AT_START,
-            )
-
-    result = model.solve()
-
-    assert_equal(result.solve_status, "Optimal")
-    assert_equal(result.objective_value, 51)
 
 
 def test_jobshop():

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -691,51 +691,6 @@ def test_timing_precedence(prec_type: Constraint, expected_makespan: int):
 @pytest.mark.parametrize(
     "prec_type,expected_makespan",
     [
-        # start 0 + delay 1 == start 1
-        (Constraint.START_AT_START, 3),
-        # start 1 + delay 1 == end 3
-        (Constraint.START_AT_END, 3),
-        # start 0 + delay 1 <= start 1
-        (Constraint.START_BEFORE_START, 3),
-        # start 0 + delay 1 <= end 2
-        (Constraint.START_BEFORE_END, 2),
-        # end 2 + delay 1 == start 0
-        (Constraint.END_AT_START, 5),
-        # end 2 + delay 1 == end 2
-        (Constraint.END_AT_END, 3),
-        # end 2 + delay 1 <= start 3
-        (Constraint.END_BEFORE_START, 5),
-        # end 2 + delay 1 <= end 3
-        (Constraint.END_BEFORE_END, 3),
-    ],
-)
-def test_timing_precedence_with_one_delay(
-    prec_type: Constraint, expected_makespan: int
-):
-    """
-    Tests that precedence constraints with delays are respected. This
-    example is similar to `test_precedence`, but with a delay of 1.
-    """
-    model = Model()
-
-    job = model.add_job()
-    machines = [model.add_machine(), model.add_machine()]
-    operations = [model.add_operation(job=job) for _ in range(2)]
-
-    for machine in machines:
-        for operation in operations:
-            model.add_processing_time(machine, operation, duration=2)
-
-    model.add_constraint(operations[0], operations[1], prec_type, delay=1)
-
-    result = model.solve()
-
-    assert_equal(result.objective_value, expected_makespan)
-
-
-@pytest.mark.parametrize(
-    "prec_type,expected_makespan",
-    [
         (Constraint.PREVIOUS, 2),  # TODO needs better test
         (Constraint.SAME_UNIT, 4),
         (Constraint.DIFFERENT_UNIT, 2),

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -7,13 +7,12 @@ from numpy.testing import assert_allclose, assert_equal, assert_raises
 
 from pyjobshop.Model import Model
 from pyjobshop.ProblemData import (
-    AssignmentPrecedence,
     Job,
     Machine,
     Objective,
     Operation,
+    Precedence,
     ProblemData,
-    TimingPrecedence,
 )
 from pyjobshop.Solution import Task
 
@@ -164,11 +163,9 @@ def test_problem_data_input_parameter_attributes():
     operations = [Operation() for _ in range(5)]
     job2ops = [[0], [1], [2], [3], [4]]
     processing_times = {(i, j): 1 for i in range(5) for j in range(5)}
-    timing_precedences = {
-        key: [TimingPrecedence.END_BEFORE_START]
-        for key in ((0, 1), (2, 3), (4, 5))
+    precedences = {
+        key: [Precedence.END_BEFORE_START] for key in ((0, 1), (2, 3), (4, 5))
     }
-    assignment_precedences = {(0, 1): [AssignmentPrecedence.PREVIOUS]}
     setup_times = np.ones((5, 5, 5), dtype=int)
     process_plans = [[[0, 1, 2, 3, 4]]]
     planning_horizon = 100
@@ -180,8 +177,7 @@ def test_problem_data_input_parameter_attributes():
         operations,
         job2ops,
         processing_times,
-        timing_precedences,
-        assignment_precedences,
+        precedences,
         setup_times,
         process_plans,
         planning_horizon,
@@ -193,8 +189,7 @@ def test_problem_data_input_parameter_attributes():
     assert_equal(data.operations, operations)
     assert_equal(data.job2ops, job2ops)
     assert_equal(data.processing_times, processing_times)
-    assert_equal(data.timing_precedences, timing_precedences)
-    assert_equal(data.assignment_precedences, assignment_precedences)
+    assert_equal(data.precedences, precedences)
     assert_allclose(data.setup_times, setup_times)
     assert_equal(data.process_plans, process_plans)
     assert_equal(data.planning_horizon, planning_horizon)
@@ -235,18 +230,12 @@ def test_problem_data_default_values():
     machines = [Machine() for _ in range(1)]
     operations = [Operation() for _ in range(1)]
     job2ops = [[0]]
-    timing_precedences = {(0, 1): [TimingPrecedence.END_BEFORE_START]}
+    precedences = {(0, 1): [Precedence.END_BEFORE_START]}
     processing_times = {(0, 0): 1}
     data = ProblemData(
-        jobs,
-        machines,
-        operations,
-        job2ops,
-        processing_times,
-        timing_precedences,
+        jobs, machines, operations, job2ops, processing_times, precedences
     )
 
-    assert_equal(data.assignment_precedences, {})
     assert_allclose(data.setup_times, np.zeros((1, 1, 1), dtype=int))
     assert_equal(data.process_plans, [])
     assert_equal(data.planning_horizon, None)
@@ -282,7 +271,6 @@ def test_problem_data_raises_when_invalid_arguments(
             [Operation()],
             [[0]],
             processing_times,
-            {},
             {},
             setup_times.astype(int),
             planning_horizon=planning_horizon,
@@ -662,26 +650,24 @@ def test_optional_operations():
     "prec_type,expected_makespan",
     [
         # start 0 == start 0
-        (TimingPrecedence.START_AT_START, 2),
+        (Precedence.START_AT_START, 2),
         # start 2 == end 2
-        (TimingPrecedence.START_AT_END, 4),
+        (Precedence.START_AT_END, 4),
         # start 0 <= start 0
-        (TimingPrecedence.START_BEFORE_START, 2),
+        (Precedence.START_BEFORE_START, 2),
         # start 0 <= end 2
-        (TimingPrecedence.START_BEFORE_END, 2),
+        (Precedence.START_BEFORE_END, 2),
         # end 2 == start 2
-        (TimingPrecedence.END_AT_START, 4),
+        (Precedence.END_AT_START, 4),
         # end 2 == end 2
-        (TimingPrecedence.END_AT_END, 2),
+        (Precedence.END_AT_END, 2),
         # end 2 <= start 2
-        (TimingPrecedence.END_BEFORE_START, 4),
+        (Precedence.END_BEFORE_START, 4),
         # end 2 <= end 2
-        (TimingPrecedence.END_BEFORE_END, 2),
+        (Precedence.END_BEFORE_END, 2),
     ],
 )
-def test_timing_precedence(
-    prec_type: TimingPrecedence, expected_makespan: int
-):
+def test_precedence(prec_type: Precedence, expected_makespan: int):
     """
     Tests that timing precedence constraints are respected. This example
     uses two operations and two machines with processing times of 2.
@@ -696,7 +682,7 @@ def test_timing_precedence(
         for operation in operations:
             model.add_processing_time(machine, operation, duration=2)
 
-    model.add_timing_precedence(operations[0], operations[1], prec_type)
+    model.add_precedence(operations[0], operations[1], prec_type)
 
     result = model.solve()
 
@@ -707,29 +693,29 @@ def test_timing_precedence(
     "prec_type,expected_makespan",
     [
         # start 0 + delay 1 == start 1
-        (TimingPrecedence.START_AT_START, 3),
+        (Precedence.START_AT_START, 3),
         # start 1 + delay 1 == end 3
-        (TimingPrecedence.START_AT_END, 3),
+        (Precedence.START_AT_END, 3),
         # start 0 + delay 1 <= start 1
-        (TimingPrecedence.START_BEFORE_START, 3),
+        (Precedence.START_BEFORE_START, 3),
         # start 0 + delay 1 <= end 2
-        (TimingPrecedence.START_BEFORE_END, 2),
+        (Precedence.START_BEFORE_END, 2),
         # end 2 + delay 1 == start 0
-        (TimingPrecedence.END_AT_START, 5),
+        (Precedence.END_AT_START, 5),
         # end 2 + delay 1 == end 2
-        (TimingPrecedence.END_AT_END, 3),
+        (Precedence.END_AT_END, 3),
         # end 2 + delay 1 <= start 3
-        (TimingPrecedence.END_BEFORE_START, 5),
+        (Precedence.END_BEFORE_START, 5),
         # end 2 + delay 1 <= end 3
-        (TimingPrecedence.END_BEFORE_END, 3),
+        (Precedence.END_BEFORE_END, 3),
     ],
 )
-def test_timing_precedence_with_one_delay(
-    prec_type: TimingPrecedence, expected_makespan: int
+def test_precedence_with_one_delay(
+    prec_type: Precedence, expected_makespan: int
 ):
     """
-    Tests that timing precedence constraints with delays are respected. This
-    example is similar to `test_timing_precedence`, but with a delay of 1.
+    Tests that precedence constraints with delays are respected. This
+    example is similar to `test_precedence`, but with a delay of 1.
     """
     model = Model()
 
@@ -741,9 +727,7 @@ def test_timing_precedence_with_one_delay(
         for operation in operations:
             model.add_processing_time(machine, operation, duration=2)
 
-    model.add_timing_precedence(
-        operations[0], operations[1], prec_type, delay=1
-    )
+    model.add_precedence(operations[0], operations[1], prec_type, delay=1)
 
     result = model.solve()
 
@@ -753,14 +737,12 @@ def test_timing_precedence_with_one_delay(
 @pytest.mark.parametrize(
     "prec_type,expected_makespan",
     [
-        (AssignmentPrecedence.PREVIOUS, 2),  # TODO needs better test
-        (AssignmentPrecedence.SAME_UNIT, 4),
-        (AssignmentPrecedence.DIFFERENT_UNIT, 2),
+        (Precedence.PREVIOUS, 2),  # TODO needs better test
+        (Precedence.SAME_UNIT, 4),
+        (Precedence.DIFFERENT_UNIT, 2),
     ],
 )
-def test_assignment_precedence(
-    prec_type: AssignmentPrecedence, expected_makespan: int
-):
+def test_assignment_precedence(prec_type: Precedence, expected_makespan: int):
     """
     Tests that assignment precedence constraints are respected. This example
     uses two operations and two machines with processing times of 2.
@@ -775,7 +757,7 @@ def test_assignment_precedence(
         for operation in operations:
             model.add_processing_time(machine, operation, duration=2)
 
-    model.add_assignment_precedence(operations[0], operations[1], prec_type)
+    model.add_precedence(operations[0], operations[1], prec_type)
 
     result = model.solve()
 
@@ -1006,10 +988,10 @@ def test_blocking_flowshop():
 
         # Create precedence constraints between operations.
         for idx in range(len(operations) - 1):
-            model.add_timing_precedence(
+            model.add_precedence(
                 operations[idx],
                 operations[idx + 1],
-                TimingPrecedence.END_AT_START,
+                Precedence.END_AT_START,
             )
 
     result = model.solve()
@@ -1052,9 +1034,7 @@ def test_jobshop():
         # Impose linear routing precedence constraints.
         for op_idx in range(1, len(operations)):
             op1, op2 = operations[op_idx - 1], operations[op_idx]
-            model.add_timing_precedence(
-                op1, op2, TimingPrecedence.END_BEFORE_START
-            )
+            model.add_precedence(op1, op2, Precedence.END_BEFORE_START)
 
     result = model.solve()
 


### PR DESCRIPTION
This PR merges TimingPrecedence and AssignmentPrecedence into one `Constraint` class. This significantly simplifies the interface. 

I want to distinguish between the constraint types at some point to support delays in timing precedence, but for now this is OK.

Part of #78.