### PR TITLE
Remove Operation optionality and process plans

### DIFF
--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -179,7 +179,6 @@ class Model:
         earliest_end: Optional[int] = None,
         latest_end: Optional[int] = None,
         fixed_duration: bool = True,
-        optional: bool = False,
         name: str = "",
     ) -> Operation:
         """
@@ -199,8 +198,6 @@ class Model:
             Latest end time of the operation.
         fixed_duration
             Whether the duration of the operation is fixed. Defaults to True.
-        optional
-            Whether processing this operation is optional. Defaults to False.
         name
             Name of the operation.
 
@@ -215,7 +212,6 @@ class Model:
             earliest_end,
             latest_end,
             fixed_duration,
-            optional,
             name,
         )
 

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -31,7 +31,6 @@ class Model:
             tuple[int, int], list[Constraint]
         ] = defaultdict(list)
         self._setup_times: dict[tuple[int, int, int], int] = {}
-        self._process_plans: list[list[list[int]]] = []
         self._planning_horizon: Optional[int] = None
         self._objective: Objective = Objective.MAKESPAN
 
@@ -90,7 +89,6 @@ class Model:
             processing_times=self._processing_times,
             constraints=self._constraints,
             setup_times=setup_times,
-            process_plans=self._process_plans,
             planning_horizon=self._planning_horizon,
             objective=self._objective,
         )
@@ -302,21 +300,6 @@ class Model:
         op_idx2 = self._id2op[id(operation2)]
 
         self._setup_times[machine_idx, op_idx1, op_idx2] = duration
-
-    def add_process_plan(self, *plans: list[Operation]):
-        """
-        Adds one or multiple process plans. Each plan is a list of operations.
-        Exactly one process plan is selected, meaning that all operations in
-        the selected plan are required to be processed.
-
-        Parameters
-        ----------
-        plans
-            The plans to be added. Each plan is a list of operations. Multiple
-            plans can be passed as separate arguments.
-        """
-        ids = [[self._id2op[id(op)] for op in plan] for plan in plans]
-        self._process_plans.append(ids)
 
     def set_planning_horizon(self, horizon: int):
         """

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -144,8 +144,6 @@ class Operation:
         machine). If the duration is not fixed, then the operation duration
         can take longer than the processing time, e.g., due to blocking.
         Default is True.
-    optional
-        Whether processing this operation is optional. Defaults to False.
     name
         Name of the operation.
     """
@@ -157,7 +155,6 @@ class Operation:
         earliest_end: Optional[int] = None,
         latest_end: Optional[int] = None,
         fixed_duration: bool = True,
-        optional: bool = False,
         name: str = "",
     ):
         if (
@@ -179,7 +176,6 @@ class Operation:
         self._earliest_end = earliest_end
         self._latest_end = latest_end
         self._fixed_duration = fixed_duration
-        self._optional = optional
         self._name = name
 
     @property
@@ -201,10 +197,6 @@ class Operation:
     @property
     def fixed_duration(self) -> bool:
         return self._fixed_duration
-
-    @property
-    def optional(self) -> bool:
-        return self._optional
 
     @property
     def name(self) -> str:

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -294,11 +294,6 @@ class ProblemData:
         Sequence-dependent setup times between operations on a given machine.
         The first dimension of the array is indexed by the machine index. The
         last two dimensions of the array are indexed by operation indices.
-    process_plans
-        List of processing plans. Each process plan represents a list
-        containing lists of operation indices, one of which is selected to be
-        scheduled. All operations from the selected list are then scheduled,
-        while operations from unselected lists will not be scheduled.
     planning_horizon
         The planning horizon value. Default is None, meaning that the planning
         horizon is unbounded.
@@ -315,7 +310,6 @@ class ProblemData:
         processing_times: dict[tuple[int, int], int],
         constraints: _CONSTRAINTS_TYPE,
         setup_times: Optional[np.ndarray] = None,
-        process_plans: Optional[list[list[list[int]]]] = None,
         planning_horizon: Optional[int] = None,
         objective: Objective = Objective.MAKESPAN,
     ):
@@ -333,9 +327,6 @@ class ProblemData:
             setup_times
             if setup_times is not None
             else np.zeros((num_mach, num_ops, num_ops), dtype=int)
-        )
-        self._process_plans = (
-            process_plans if process_plans is not None else []
         )
         self._planning_horizon = planning_horizon
         self._objective = objective
@@ -447,21 +438,6 @@ class ProblemData:
             operation indices.
         """
         return self._setup_times
-
-    @property
-    def process_plans(self) -> list[list[list[int]]]:
-        """
-        List of process plans. Each process plan represents a list containing
-        lists of operation indices, one of which is selected to be scheduled.
-        All operations from the selected list are then scheduled, while
-        operations from unselected lists will not be scheduled.
-
-        Returns
-        -------
-        list[list[list[int]]]
-            List of processing plans.
-        """
-        return self._process_plans
 
     @property
     def planning_horizon(self) -> Optional[int]:

--- a/pyjobshop/cp/constraints.py
+++ b/pyjobshop/cp/constraints.py
@@ -144,34 +144,6 @@ def operation_constraints(
     return []  # no constraints because we use setters
 
 
-def optional_operation_selection_constraints(
-    m: CpoModel, data: ProblemData, op_vars: OpVars
-) -> list[CpoExpr]:
-    """
-    Creates the process plan selection constraints. These constraints
-    ensure that for process plan, exactly one operation list is selected
-    and all operations in that list are set to present.
-    """
-    constraints = []
-
-    for plan in data.process_plans:
-        presence_by_plan = []
-
-        for operations in plan:
-            presence = [m.presence_of(op_vars[idx]) for idx in operations]
-            presence_by_plan.append(m.logical_and(presence))
-
-            # Presence of operation intervals is the same for all operations
-            # within one process plan option.
-            for idx in range(len(operations) - 1):
-                constraints.append(presence[idx] == presence[idx + 1])
-
-        # Select exactly one group per process plan.
-        constraints.append(m.sum(presence_by_plan) == 1)
-
-    return constraints
-
-
 def planning_horizon_constraints(
     m: CpoModel,
     data: ProblemData,

--- a/pyjobshop/cp/default_model.py
+++ b/pyjobshop/cp/default_model.py
@@ -10,7 +10,6 @@ from .constraints import (
     no_overlap_and_setup_time_constraints,
     operation_constraints,
     operation_graph_constraints,
-    optional_operation_selection_constraints,
     planning_horizon_constraints,
     processing_time_constraints,
 )
@@ -66,7 +65,6 @@ def default_model(data: ProblemData) -> CpoModel:
     model.add(operation_constraints(model, data, op_vars))
     model.add(alternative_constraints(model, data, op_vars, task_vars))
     model.add(no_overlap_and_setup_time_constraints(model, data, seq_vars))
-    model.add(optional_operation_selection_constraints(model, data, op_vars))
     model.add(
         planning_horizon_constraints(model, data, job_vars, task_vars, op_vars)
     )

--- a/pyjobshop/cp/variables.py
+++ b/pyjobshop/cp/variables.py
@@ -20,7 +20,7 @@ def operation_variables(
     Creates an interval variable for each operation in the problem.
     """
     return [
-        m.interval_var(name=f"O{idx}", optional=operation.optional)
+        m.interval_var(name=f"O{idx}")
         for idx, operation in enumerate(data.operations)
     ]
 

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -126,7 +126,6 @@ def test_add_operation_attributes():
         earliest_end=3,
         latest_end=4,
         fixed_duration=True,
-        optional=False,
         name="operation",
     )
 
@@ -135,7 +134,6 @@ def test_add_operation_attributes():
     assert_equal(operation.earliest_end, 3)
     assert_equal(operation.latest_end, 4)
     assert_equal(operation.fixed_duration, True)
-    assert_equal(operation.optional, False)
     assert_equal(operation.name, "operation")
 
 

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -31,7 +31,6 @@ def test_model_to_data():
     model.add_setup_time(mach1, op1, op2, 3)
     model.add_setup_time(mach2, op1, op2, 4)
 
-    model.add_process_plan([op1], [op2])
     model.set_planning_horizon(100)
     model.set_objective(Objective.TOTAL_COMPLETION_TIME)
 
@@ -56,7 +55,6 @@ def test_model_to_data():
         },
     )
     assert_equal(data.setup_times, [[[0, 3], [0, 0]], [[0, 4], [0, 0]]])
-    assert_equal(data.process_plans, [[[0], [1]]])
     assert_equal(data.planning_horizon, 100)
     assert_equal(data.objective, Objective.TOTAL_COMPLETION_TIME)
 
@@ -80,7 +78,6 @@ def test_model_to_data_default_values():
     assert_equal(data.processing_times, {})
     assert_equal(data.constraints, {})
     assert_equal(data.setup_times, [[[0]]])
-    assert_equal(data.process_plans, [])
     assert_equal(data.planning_horizon, None)
     assert_equal(data.objective, Objective.MAKESPAN)
 

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -109,14 +109,20 @@ def test_operation_attributes():
     """
     Tests that the attributes of the Operation class are set correctly.
     """
-    operation = Operation(1, 2, 3, 4, False, True, name="TestOperation")
+    operation = Operation(
+        earliest_start=1,
+        latest_start=2,
+        earliest_end=3,
+        latest_end=4,
+        fixed_duration=False,
+        name="TestOperation",
+    )
 
     assert_equal(operation.earliest_start, 1)
     assert_equal(operation.latest_start, 2)
     assert_equal(operation.earliest_end, 3)
     assert_equal(operation.latest_end, 4)
     assert_equal(operation.fixed_duration, False)
-    assert_equal(operation.optional, True)
     assert_equal(operation.name, "TestOperation")
 
     # Also test that default values are set correctly.
@@ -127,7 +133,6 @@ def test_operation_attributes():
     assert_equal(operation.earliest_end, None)
     assert_equal(operation.latest_end, None)
     assert_equal(operation.fixed_duration, True)
-    assert_equal(operation.optional, False)
     assert_equal(operation.name, "")
 
 
@@ -615,30 +620,6 @@ def test_operation_non_fixed_duration():
     assert_equal(result.solve_status, "Optimal")
     assert_equal(result.objective_value, 10)
     assert_equal(result.best.schedule, [Task(0, 0, 0, 10)])
-
-
-def test_optional_operations():
-    """
-    Tests that optional operations are not scheduled.
-    """
-    model = Model()
-
-    job = model.add_job()
-    machine = model.add_machine()
-    operations = [
-        model.add_operation(job=job),
-        model.add_operation(job=job, optional=True),
-    ]
-
-    model.add_processing_time(machine, operations[0], duration=10)
-    model.add_processing_time(machine, operations[1], duration=15)
-
-    result = model.solve()
-
-    # Operation 2 is not scheduled, so the makespan is 10, just the duration
-    # of operation 1.
-    assert_equal(result.solve_status, "Optimal")
-    assert_equal(result.objective_value, 10)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -166,7 +166,6 @@ def test_problem_data_input_parameter_attributes():
         key: [Constraint.END_BEFORE_START] for key in ((0, 1), (2, 3), (4, 5))
     }
     setup_times = np.ones((5, 5, 5), dtype=int)
-    process_plans = [[[0, 1, 2, 3, 4]]]
     planning_horizon = 100
     objective = Objective.TOTAL_COMPLETION_TIME
 
@@ -178,7 +177,6 @@ def test_problem_data_input_parameter_attributes():
         processing_times,
         constraints,
         setup_times,
-        process_plans,
         planning_horizon,
         objective,
     )
@@ -190,7 +188,6 @@ def test_problem_data_input_parameter_attributes():
     assert_equal(data.processing_times, processing_times)
     assert_equal(data.constraints, constraints)
     assert_allclose(data.setup_times, setup_times)
-    assert_equal(data.process_plans, process_plans)
     assert_equal(data.planning_horizon, planning_horizon)
     assert_equal(data.objective, objective)
 
@@ -236,7 +233,6 @@ def test_problem_data_default_values():
     )
 
     assert_allclose(data.setup_times, np.zeros((1, 1, 1), dtype=int))
-    assert_equal(data.process_plans, [])
     assert_equal(data.planning_horizon, None)
     assert_equal(data.objective, Objective.MAKESPAN)
 
@@ -716,31 +712,6 @@ def test_assignment_constraint(prec_type: Constraint, expected_makespan: int):
     result = model.solve()
 
     assert_equal(result.objective_value, expected_makespan)
-
-
-def test_process_plans():
-    """
-    Tests that setting optional plans works correctly.
-    """
-    model = Model()
-
-    job = model.add_job()
-    machine = model.add_machine()
-    operations = [
-        model.add_operation(job=job, optional=True) for _ in range(4)
-    ]
-
-    for operation, duration in zip(operations, [1, 2, 3, 4]):
-        model.add_processing_time(machine, operation, duration)
-
-    plan1 = [operations[0], operations[1]]
-    plan2 = [operations[2], operations[3]]
-    model.add_process_plan(plan1, plan2)
-
-    result = model.solve()
-
-    # Schedule plan 1, so the makespan is 1 + 2 = 3.
-    assert_equal(result.objective_value, 3)
 
 
 def test_tight_planning_horizon_results_in_infeasiblity():


### PR DESCRIPTION
This PR removes the Operation class's optional field and process plans. This is an attempt to simplify the feature set to make OR-Tools support more convenient.