### PR TITLE
Remove Machine downtimes

### DIFF
--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Iterable, Optional
+from typing import Optional
 
 import numpy as np
 from docplex.cp.solution import CpoSolveResult
@@ -135,20 +135,13 @@ class Model:
         return job
 
     def add_machine(
-        self,
-        downtimes: Iterable[tuple[int, int]] = (),
-        allow_overlap: bool = False,
-        name: str = "",
+        self, allow_overlap: bool = False, name: str = ""
     ) -> Machine:
         """
         Adds a machine to the model.
 
         Parameters
         ----------
-        downtimes
-            List of downtimes for the machine. A downtime is a time interval
-            [start, end) during which the machine is unavailable for
-            processing. Defaults to no downtimes.
         allow_overlap
             Whether it is allowed to schedule multiple operations on the
             machine at the same time. Default ``False``.
@@ -160,11 +153,7 @@ class Model:
         Machine
             The created machine.
         """
-        machine = Machine(
-            downtimes=downtimes,
-            allow_overlap=allow_overlap,
-            name=name,
-        )
+        machine = Machine(allow_overlap=allow_overlap, name=name)
 
         self._id2machine[id(machine)] = len(self.machines)
         self._machines.append(machine)

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -1,6 +1,6 @@
 import bisect
 from enum import Enum
-from typing import Iterable, Optional
+from typing import Optional
 
 import enum_tools.documentation
 import numpy as np
@@ -86,10 +86,6 @@ class Machine:
 
     Parameters
     ----------
-    downtimes
-        List of downtimes for the machine. A downtime is a time interval
-        [start, end) during which the machine is unavailable for processing.
-        Defaults to no downtimes.
     allow_overlap
         Whether it is allowed to schedule multiple operations on the machine
         at the same time. Default is False.
@@ -97,23 +93,9 @@ class Machine:
         Name of the machine.
     """
 
-    def __init__(
-        self,
-        downtimes: Iterable[tuple[int, int]] = (),
-        allow_overlap: bool = False,
-        name: str = "",
-    ):
-        for start, end in downtimes:
-            if start > end:
-                raise ValueError("Must have downtime start <= end.")
-
-        self._downtimes = downtimes
+    def __init__(self, allow_overlap: bool = False, name: str = ""):
         self._allow_overlap = allow_overlap
         self._name = name
-
-    @property
-    def downtimes(self) -> Iterable[tuple[int, int]]:
-        return self._downtimes
 
     @property
     def allow_overlap(self) -> bool:

--- a/pyjobshop/cp/constraints.py
+++ b/pyjobshop/cp/constraints.py
@@ -3,7 +3,6 @@ from itertools import product
 
 import numpy as np
 from docplex.cp.expression import CpoExpr, CpoIntervalVar, CpoSequenceVar
-from docplex.cp.function import CpoStepFunction
 from docplex.cp.model import CpoModel
 
 from pyjobshop.ProblemData import ProblemData
@@ -69,27 +68,6 @@ def job_operation_constraints(
             constraints.append(
                 m.start_of(op_var) >= data.jobs[job].release_date
             )
-
-    return constraints
-
-
-def machine_data_constraints(
-    m: CpoModel, data: ProblemData, task_vars: TaskVars
-) -> list[CpoExpr]:
-    """
-    Creates constraints related to the machine data.
-    """
-    constraints = []
-
-    for (_, machine), var in task_vars.items():
-        machine_data = data.machines[machine]
-
-        for start, end in machine_data.downtimes:
-            step = CpoStepFunction()
-            step.set_value(0, _INT_MAX, 1)
-            step.set_value(start, end, 0)
-
-            constraints.append(m.forbid_extent(var, step))
 
     return constraints
 

--- a/pyjobshop/cp/default_model.py
+++ b/pyjobshop/cp/default_model.py
@@ -6,7 +6,6 @@ from .constraints import (
     alternative_constraints,
     job_data_constraints,
     job_operation_constraints,
-    machine_data_constraints,
     no_overlap_and_setup_time_constraints,
     operation_constraints,
     operation_graph_constraints,
@@ -60,7 +59,6 @@ def default_model(data: ProblemData) -> CpoModel:
         raise ValueError(f"Unknown objective: {data.objective}")
 
     model.add(job_data_constraints(model, data, job_vars))
-    model.add(machine_data_constraints(model, data, task_vars))
     model.add(job_operation_constraints(model, data, job_vars, op_vars))
     model.add(operation_constraints(model, data, op_vars))
     model.add(alternative_constraints(model, data, op_vars, task_vars))

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -105,11 +105,8 @@ def test_add_machine_attributes():
     """
     model = Model()
 
-    machine = model.add_machine(
-        downtimes=[(0, 1)], allow_overlap=True, name="machine"
-    )
+    machine = model.add_machine(allow_overlap=True, name="machine")
 
-    assert_equal(machine.downtimes, [(0, 1)])
     assert_equal(machine.allow_overlap, True)
     assert_equal(machine.name, "machine")
 

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -76,33 +76,14 @@ def test_machine_attributes():
     # Let's first test the default values.
     machine = Machine()
 
-    assert_equal(machine.downtimes, ())
     assert_equal(machine.allow_overlap, False)
     assert_equal(machine.name, "")
 
     # Now test with some values.
-    machine = Machine([(1, 2)], True, name="TestMachine")
+    machine = Machine(allow_overlap=True, name="TestMachine")
 
-    assert_equal(machine.downtimes, [(1, 2)])
     assert_equal(machine.allow_overlap, True)
     assert_equal(machine.name, "TestMachine")
-
-
-@pytest.mark.parametrize(
-    "downtimes",
-    [
-        [(1, 0)],  # start > end
-    ],
-)
-def test_machine_attributes_raises_invalid_parameters(
-    downtimes: list[tuple[int, int]],
-):
-    """
-    Tests that a ValueError is raised when invalid parameters are passed to
-    Machine.
-    """
-    with assert_raises(ValueError):
-        Machine(downtimes)
 
 
 def test_operation_attributes():
@@ -367,44 +348,6 @@ def test_job_deadline_infeasible():
     result = model.solve()
 
     # Operation's processing time is 2, but job deadline is 1.
-    assert_equal(result.solve_status, "Infeasible")
-
-
-def test_machine_downtime_single_interval():
-    """
-    Tests that operations are scheduled around machine downtimes.
-    """
-    model = Model()
-    job = model.add_job()
-    machine = model.add_machine([(0, 2)])
-    operation = model.add_operation(job=job)
-
-    model.add_processing_time(machine, operation, duration=2)
-
-    result = model.solve()
-
-    # Machine is down between (0, 2) onwards, so the makespan is be 4.
-    assert_equal(result.solve_status, "Optimal")
-    assert_equal(result.objective_value, 4)
-
-
-def test_restrictive_machine_downtime_and_horizon():
-    """
-    Tests that a restrictive machine downtime and planning horizon results
-    in an infeasible model.
-    """
-    model = Model()
-    job = model.add_job()
-    machine = model.add_machine([(0, 2)])
-    operation = model.add_operation(job=job)
-
-    model.add_processing_time(machine, operation, duration=2)
-    model.set_planning_horizon(3)
-
-    result = model.solve()
-
-    # Machine is down between (0, 2) onwards, but the planning horizon is
-    # only 3, so the operation cannot be scheduled.
     assert_equal(result.solve_status, "Infeasible")
 
 


### PR DESCRIPTION
This PR removes machine downtimes. Like #111, this is an attempt to make the codebase simpler to integrate OR-tools more easily.

Related: 
- #96 
- #28 