### PR TITLE
[OR-Tools] Previous constraint

### DIFF
--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from itertools import product
 
 import numpy as np
@@ -11,7 +10,7 @@ from .variables import AssignmentVar, JobVar, OperationVar, SequenceVar
 JobVars = list[JobVar]
 OperationVars = list[OperationVar]
 AssignmentVars = dict[tuple[int, int], AssignmentVar]
-SquenceVars = list[SequenceVar]
+SequenceVars = list[SequenceVar]
 
 
 def job_data_constraints(m: CpModel, data: ProblemData, job_vars: JobVars):
@@ -69,7 +68,7 @@ def operation_graph_constraints(
     data: ProblemData,
     op_vars: OperationVars,
     assign: AssignmentVars,
-    seq_vars: SquenceVars,
+    seq_vars: SequenceVars,
 ):
     for (idx1, idx2), op_constraints in data.constraints.items():
         op_var1 = op_vars[idx1]
@@ -155,19 +154,15 @@ def alternative_constraints(
 
 
 def no_overlap_constraints(
-    m: CpModel, data: ProblemData, assign: AssignmentVars
+    m: CpModel, data: ProblemData, seq_vars: SequenceVars
 ):
     """
-    Creates the no-overlap constraints for machines, ensuring that no two
+    Creates the no overlap constraints for machines, ensuring that no two
     intervals in a sequence variable are overlapping.
     """
-    sequences = defaultdict(list)
-    for (_, machine), var in assign.items():
-        sequences[machine].append(var)
-
     for machine in range(data.num_machines):
         if not data.machines[machine].allow_overlap:
-            m.AddNoOverlap([var.interval for var in sequences[machine]])
+            m.AddNoOverlap([var.interval for var in seq_vars[machine].tasks])
 
 
 def processing_time_constraints(
@@ -191,7 +186,7 @@ def processing_time_constraints(
 def setup_times_constraints(
     m: CpModel,
     data: ProblemData,
-    seq_vars,
+    seq_vars: SequenceVars,
 ):
     """
     Creates the setup time constraints for each machine, ensuring that the

--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -120,7 +120,7 @@ def operation_graph_constraints(
 
                     # Equivalent: arc_lit <=> var1.is_present & var2.is_present
                     m.AddBoolOr(
-                        [var1.is_present.Not(), var2.is_present.Not(), arc_lit]
+                        [arc_lit, var1.is_present.Not(), var2.is_present.Not()]
                     )
                     m.AddImplication(arc_lit, var1.is_present)
                     m.AddImplication(arc_lit, var2.is_present)

--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -111,7 +111,8 @@ def operation_graph_constraints(
                     idx1 = sequence.tasks.index(var1)
                     idx2 = sequence.tasks.index(var2)
                     arc_lit = sequence.arcs[idx1, idx2]
-                    # https://github.com/google/or-tools/blob/stable/ortools/sat/docs/boolean_logic.md#product-of-two-boolean-variables
+
+                    # Equivalent: arc_lit <=> var1.is_present & var2.is_present
                     m.AddBoolOr(
                         [var1.is_present.Not(), var2.is_present.Not(), arc_lit]
                     )
@@ -193,14 +194,14 @@ def setup_times_constraints(
     setup times are respected.
     """
     for machine in range(data.num_machines):
-        arcs = []
         sequence = seq_vars[machine]
         assigns = sequence.tasks
         starts = sequence.starts
         ends = sequence.ends
         arc_lits = sequence.arcs
-        setup_times = data.setup_times[machine]
+        arcs = []
 
+        setup_times = data.setup_times[machine]
         if np.all(setup_times == 0):
             continue
 
@@ -240,8 +241,7 @@ def setup_times_constraints(
                 # TODO This automatically enforces classic start -> end
                 # precedence constraints and also does not allow for overlap.
                 # We need to validate this to catch it.
-                op1 = var1.task_idx
-                op2 = var2.task_idx
+                op1, op2 = var1.task_idx, var2.task_idx
                 setup = setup_times[op1, op2]
                 m.Add(var1.end + setup <= var2.start).OnlyEnforceIf(arc_lit)
 

--- a/pyjobshop/ortools/default_model.py
+++ b/pyjobshop/ortools/default_model.py
@@ -13,7 +13,12 @@ from .constraints import (
     setup_times_constraints,
 )
 from .objectives import makespan
-from .variables import assignment_variables, job_variables, operation_variables
+from .variables import (
+    assignment_variables,
+    job_variables,
+    operation_variables,
+    sequence_variables,
+)
 
 
 def default_model(data: ProblemData) -> tuple[CpModel, list, dict]:
@@ -22,6 +27,7 @@ def default_model(data: ProblemData) -> tuple[CpModel, list, dict]:
     job_vars = job_variables(model, data)
     op_vars = operation_variables(model, data)
     assign = assignment_variables(model, data)
+    seq_vars = sequence_variables(model, data, assign)
 
     if data.objective == "makespan":
         makespan(model, data, op_vars)
@@ -35,7 +41,7 @@ def default_model(data: ProblemData) -> tuple[CpModel, list, dict]:
     alternative_constraints(model, data, op_vars, assign)
     no_overlap_constraints(model, data, assign)
     processing_time_constraints(model, data, assign)
-    setup_times_constraints(model, data, assign)
+    setup_times_constraints(model, data, seq_vars)
     operation_graph_constraints(model, data, op_vars, assign)
 
     return model, op_vars, assign

--- a/pyjobshop/ortools/default_model.py
+++ b/pyjobshop/ortools/default_model.py
@@ -44,6 +44,8 @@ def default_model(data: ProblemData) -> tuple[CpModel, list, dict]:
     processing_time_constraints(model, data, assign)
     setup_time_constraints(model, data, seq_vars)
     operation_graph_constraints(model, data, op_vars, assign, seq_vars)
+
+    # Must be called last to ensure that sequence constriants are enforced!
     circuit_constraints(model, data, seq_vars)
 
     return model, op_vars, assign

--- a/pyjobshop/ortools/default_model.py
+++ b/pyjobshop/ortools/default_model.py
@@ -39,7 +39,7 @@ def default_model(data: ProblemData) -> tuple[CpModel, list, dict]:
     job_operation_constraints(model, data, job_vars, op_vars)
     operation_constraints(model, data, op_vars)
     alternative_constraints(model, data, op_vars, assign)
-    no_overlap_constraints(model, data, assign)
+    no_overlap_constraints(model, data, seq_vars)
     processing_time_constraints(model, data, assign)
     setup_times_constraints(model, data, seq_vars)
     operation_graph_constraints(model, data, op_vars, assign, seq_vars)

--- a/pyjobshop/ortools/default_model.py
+++ b/pyjobshop/ortools/default_model.py
@@ -42,6 +42,6 @@ def default_model(data: ProblemData) -> tuple[CpModel, list, dict]:
     no_overlap_constraints(model, data, assign)
     processing_time_constraints(model, data, assign)
     setup_times_constraints(model, data, seq_vars)
-    operation_graph_constraints(model, data, op_vars, assign)
+    operation_graph_constraints(model, data, op_vars, assign, seq_vars)
 
     return model, op_vars, assign

--- a/pyjobshop/ortools/default_model.py
+++ b/pyjobshop/ortools/default_model.py
@@ -4,13 +4,14 @@ from pyjobshop.ProblemData import ProblemData
 
 from .constraints import (
     alternative_constraints,
+    circuit_constraints,
     job_data_constraints,
     job_operation_constraints,
     no_overlap_constraints,
     operation_constraints,
     operation_graph_constraints,
     processing_time_constraints,
-    setup_times_constraints,
+    setup_time_constraints,
 )
 from .objectives import makespan
 from .variables import (
@@ -41,7 +42,8 @@ def default_model(data: ProblemData) -> tuple[CpModel, list, dict]:
     alternative_constraints(model, data, op_vars, assign)
     no_overlap_constraints(model, data, seq_vars)
     processing_time_constraints(model, data, assign)
-    setup_times_constraints(model, data, seq_vars)
+    setup_time_constraints(model, data, seq_vars)
     operation_graph_constraints(model, data, op_vars, assign, seq_vars)
+    circuit_constraints(model, data, seq_vars)
 
     return model, op_vars, assign

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -24,6 +24,28 @@ class OperationVar:
 
 @dataclass
 class AssignmentVar:
+    """
+    Variables that represent an assignment of a task to a machine.
+
+    Parameters
+    ----------
+    task_idx
+        The index of the task.
+    interval
+        The interval variable representing the assignment of the task.
+    start
+        The start variable time of the interval.
+    duration
+        The duration variable of the interval.
+    end
+        The end variable time of the interval.
+    is_present
+        The boolean variable indicating whether the internval is present.
+    rank
+        The rank variable of the interval on the machine. This is used to
+        order the intervals on the machine.
+    """
+
     task_idx: int
     interval: IntervalVar
     start: IntVar

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -40,10 +40,10 @@ class AssignmentVar:
     end
         The end variable time of the interval.
     is_present
-        The boolean variable indicating whether the internval is present.
+        The boolean variable indicating whether the interval is present.
     rank
-        The rank variable of the interval on the machine. This is used to
-        order the intervals on the machine.
+        The rank variable of the interval on the machine. Used to order the
+        intervals in the sequence variable of the machine.
     """
 
     task_idx: int
@@ -72,8 +72,8 @@ class SequenceVar:
         The arc literals between each pair of tasks. Keys are tuples of
         indices.
     is_active
-        A boolean that indicates whether the sequence is active, meaning that
-        a sequence constraint must be enforced on this machine. Default False.
+        A boolean that indicates whether the sequence is active, meaning that a
+        circuit constraint must be added for this machine. Default ``False``.
     """
 
     tasks: list[AssignmentVar]
@@ -84,8 +84,8 @@ class SequenceVar:
 
     def activate(self):
         """
-        Activates the sequence variable, meaning that a sequence constraint
-        must be enforced on this machine.
+        Activates the sequence variable, meaning that a circuit constraint
+        must be added for this machine.
         """
         self.is_active = True
 

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -71,12 +71,23 @@ class SequenceVar:
     arcs
         The arc literals between each pair of tasks. Keys are tuples of
         indices.
+    is_active
+        A boolean that indicates whether the sequence is active, meaning that
+        a sequence constraint must be enforced on this machine. Default False.
     """
 
     tasks: list[AssignmentVar]
     starts: list[BoolVarT]
     ends: list[BoolVarT]
     arcs: dict[tuple[int, int], BoolVarT]
+    is_active: bool = False
+
+    def activate(self):
+        """
+        Activates the sequence variable, meaning that a sequence constraint
+        must be enforced on this machine.
+        """
+        self.is_active = True
 
 
 def job_variables(m: CpModel, data: ProblemData) -> list[JobVar]:
@@ -167,7 +178,8 @@ def sequence_variables(
     """
     Creates a sequence variable for each machine. Sequence variables are used
     to model the ordering of intervals on a given machine. This is used for
-    modeling machine setups and sequencing task constraints.
+    modeling machine setups and sequencing task constraints, such as Previous,
+    Before, First, and Last.
     """
     variables = []
 
@@ -181,8 +193,8 @@ def sequence_variables(
 
         # Start and end literals define whether the corresponding interval
         # is first or last in the sequence, respectively.
-        starts = [m.NewBoolVar() for _ in range(num_tasks)]
-        ends = [m.NewBoolVar() for _ in range(num_tasks)]
+        starts = [m.NewBoolVar("") for _ in range(num_tasks)]
+        ends = [m.NewBoolVar("") for _ in range(num_tasks)]
 
         # Arc literals define whether two intervals are consecutive in the
         # sequence.

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -178,8 +178,8 @@ def sequence_variables(
     """
     Creates a sequence variable for each machine. Sequence variables are used
     to model the ordering of intervals on a given machine. This is used for
-    modeling machine setups and sequencing task constraints, such as Previous,
-    Before, First, and Last.
+    modeling machine setups and sequencing task constraints, such as previous,
+    before, first, last and permutations.
     """
     variables = []
 
@@ -189,28 +189,21 @@ def sequence_variables(
         machine2tasks[machine].append(var)
 
     for machine in range(data.num_machines):
-        num_tasks = len(machine2tasks[machine])
+        tasks = machine2tasks[machine]
+        num_tasks = len(tasks)
 
         # Start and end literals define whether the corresponding interval
         # is first or last in the sequence, respectively.
         starts = [m.NewBoolVar("") for _ in range(num_tasks)]
         ends = [m.NewBoolVar("") for _ in range(num_tasks)]
 
-        # Arc literals define whether two intervals are consecutive in the
-        # sequence.
+        # Arc literals indicate if two intervals are scheduled consecutively.
         arcs = {
             (i, j): m.NewBoolVar(f"{i}->{j}")
             for i in range(num_tasks)
             for j in range(num_tasks)
         }
 
-        variables.append(
-            SequenceVar(
-                tasks=machine2tasks[machine],
-                starts=starts,
-                ends=ends,
-                arcs=arcs,
-            )
-        )
+        variables.append(SequenceVar(tasks, starts, ends, arcs))
 
     return variables

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -611,8 +611,7 @@ def test_timing_precedence(prec_type: Constraint, expected_makespan: int):
 
 def test_previous_constraint():
     """
-    Tests that the previous constraint is respected. This example uses two
-    operations and two machines with processing times of 2.
+    Tests that the previous constraint is respected.
     """
     model = Model()
 

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -609,10 +609,33 @@ def test_timing_precedence(prec_type: Constraint, expected_makespan: int):
     assert_equal(result.objective, expected_makespan)
 
 
+def test_previous_constraint():
+    """
+    Tests that the previous constraint is respected. This example uses two
+    operations and two machines with processing times of 2.
+    """
+    model = Model()
+
+    job = model.add_job()
+    machine = model.add_machine()
+    operations = [model.add_operation(job=job) for _ in range(2)]
+
+    model.add_processing_time(machine, operations[0], duration=1)
+    model.add_processing_time(machine, operations[1], duration=1)
+
+    model.add_setup_time(machine, operations[1], operations[0], duration=100)
+    model.add_constraint(operations[1], operations[0], Constraint.PREVIOUS)
+
+    result = model.solve()
+
+    # Operation 1 must be scheduled before operation 0, but the setup time
+    # between them is 100, so the makespan is 1 + 100 + 1 = 102.
+    assert_equal(result.objective, 102)
+
+
 @pytest.mark.parametrize(
     "prec_type,expected_makespan",
     [
-        (Constraint.PREVIOUS, 2),  # TODO needs better test
         (Constraint.SAME_UNIT, 4),
         (Constraint.DIFFERENT_UNIT, 2),
     ],


### PR DESCRIPTION
This PR introduces the Previous constraint for OR-Tools (part of #26). Specifically:
- Introduces the `SequenceVar` class to model CP Optimizer-like sequence variables
- Implements the Previous constraint 

For future reference, it's good to note that our choice for activating circuit constraints separately is for performance reasons. I have not checked whether this matters (as presolve could possibly deal with this).