### PR TITLE
[OR-Tools] Refactor and better defaults

### DIFF
--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -98,8 +98,8 @@ class Model:
         self,
         weight: int = 1,
         release_date: int = 0,
+        deadline: int = MAX_VALUE,
         due_date: Optional[int] = None,
-        deadline: Optional[int] = None,
         name: str = "",
     ) -> Job:
         """
@@ -109,17 +109,16 @@ class Model:
         ----------
         weight
             The job importance weight, used as multiplicative factor in the
-            objective function.
+            objective function. Default 1.
         release_date
-            The earliest time that the job may start. Default is zero.
-        due_date
-            The latest time that the job should be completed before incurring
-            penalties. Default is None, meaning that there is no due date.
+            The earliest time that the job may start. Default 0.
         deadline
             The latest time by which the job must be completed. Note that a
             deadline is different from a due date; the latter does not restrict
-            the latest completion time. Default is None, meaning that there is
-            no deadline.
+            the latest completion time. Default ``MAX_VALUE``.
+        due_date
+            The latest time that the job should be completed before incurring
+            penalties. Default is None, meaning that there is no due date.
         name
             Name of the job.
 
@@ -128,7 +127,7 @@ class Model:
         Job
             The created job.
         """
-        job = Job(weight, release_date, due_date, deadline, name)
+        job = Job(weight, release_date, deadline, due_date, name)
 
         self._id2job[id(job)] = len(self.jobs)
         self._jobs.append(job)

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -164,10 +164,10 @@ class Model:
     def add_task(
         self,
         job: Optional[Job] = None,
-        earliest_start: Optional[int] = None,
-        latest_start: Optional[int] = None,
-        earliest_end: Optional[int] = None,
-        latest_end: Optional[int] = None,
+        earliest_start: int = 0,
+        latest_start: int = MAX_VALUE,
+        earliest_end: int = 0,
+        latest_end: int = MAX_VALUE,
         fixed_duration: bool = True,
         name: str = "",
     ) -> Task:
@@ -177,17 +177,17 @@ class Model:
         Parameters
         ----------
         job
-            The job that the task belongs to.
+            The job that the task belongs to. Default None.
         earliest_start
-            Earliest start time of the task.
+            Earliest start time of the task. Default 0.
         latest_start
-            Latest start time of the task.
+            Latest start time of the task. Default ``MAX_VALUE``.
         earliest_end
-            Earliest end time of the task.
+            Earliest end time of the task. Default 0.
         latest_end
-            Latest end time of the task.
+            Latest end time of the task. Default ``MAX_VALUE``.
         fixed_duration
-            Whether the duration of the task is fixed. Defaults to True.
+            Whether the duration of the task is fixed. Default True.
         name
             Name of the task.
 

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -20,16 +20,16 @@ class Job:
     ----------
     weight
         The job importance weight, used as multiplicative factor in the
-        objective function.
+        objective function. Default 1.
     release_date
-        The earliest time that the job can start processing. Default is zero.
+        The earliest time that the job may start. Default 0.
+    deadline
+        The latest time by which the job must be completed. Note that a
+        deadline is different from a due date; the latter does not restrict
+        the latest completion time. Default ``MAX_VALUE``.
     due_date
         The latest time that the job should be completed before incurring
         penalties. Default is None, meaning that there is no due date.
-    deadline
-        The latest time that the job must be completed. Note that a deadline
-        is different from a due date; the latter does not constrain the latest
-        completion time. Default is None, meaning that there is no deadline.
     name
         Name of the job.
     """
@@ -38,8 +38,8 @@ class Job:
         self,
         weight: int = 1,
         release_date: int = 0,
+        deadline: int = MAX_VALUE,
         due_date: Optional[int] = None,
-        deadline: Optional[int] = None,
         name: str = "",
     ):
         if weight < 0:
@@ -48,19 +48,19 @@ class Job:
         if release_date < 0:
             raise ValueError("Release date must be non-negative.")
 
+        if deadline < 0:
+            raise ValueError("Deadline must be non-negative.")
+
+        if release_date > deadline:
+            raise ValueError("Must have release_date <= deadline.")
+
         if due_date is not None and due_date < 0:
             raise ValueError("Due date must be non-negative.")
 
-        if deadline is not None and deadline < 0:
-            raise ValueError("Deadline must be non-negative.")
-
-        if deadline is not None and release_date > deadline:
-            raise ValueError("Must have release_date <= deadline.")
-
         self._weight = weight
         self._release_date = release_date
-        self._due_date = due_date
         self._deadline = deadline
+        self._due_date = due_date
         self._name = name
 
     @property
@@ -72,12 +72,12 @@ class Job:
         return self._release_date
 
     @property
-    def due_date(self) -> Optional[int]:
-        return self._due_date
+    def deadline(self) -> int:
+        return self._deadline
 
     @property
-    def deadline(self) -> Optional[int]:
-        return self._deadline
+    def due_date(self) -> Optional[int]:
+        return self._due_date
 
     @property
     def name(self) -> str:

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -117,44 +117,36 @@ class Task:
     Parameters
     ----------
     earliest_start
-        Earliest start time of the task.
+        Earliest start time of the task. Default 0.
     latest_start
-        Latest start time of the task.
+        Latest start time of the task. Default ``MAX_VALUE``.
     earliest_end
-        Earliest end time of the task.
+        Earliest end time of the task. Default 0.
     latest_end
-        Latest end time of the task.
+        Latest end time of the task. Default ``MAX_VALUE``.
     fixed_duration
         Whether the task has a fixed duration. A fixed duration means that
         the task duration is precisely the processing time (on a given
         machine). If the duration is not fixed, then the task duration
         can take longer than the processing time, e.g., due to blocking.
-        Default is True.
+        Default ``True``.
     name
         Name of the task.
     """
 
     def __init__(
         self,
-        earliest_start: Optional[int] = None,
-        latest_start: Optional[int] = None,
-        earliest_end: Optional[int] = None,
-        latest_end: Optional[int] = None,
+        earliest_start: int = 0,
+        latest_start: int = MAX_VALUE,
+        earliest_end: int = 0,
+        latest_end: int = MAX_VALUE,
         fixed_duration: bool = True,
         name: str = "",
     ):
-        if (
-            earliest_start is not None
-            and latest_start is not None
-            and earliest_start > latest_start
-        ):
+        if earliest_start > latest_start:
             raise ValueError("earliest_start must be <= latest_start.")
 
-        if (
-            earliest_end is not None
-            and latest_end is not None
-            and earliest_end > latest_end
-        ):
+        if earliest_end > latest_end:
             raise ValueError("earliest_end must be <= latest_end.")
 
         self._earliest_start = earliest_start
@@ -165,19 +157,19 @@ class Task:
         self._name = name
 
     @property
-    def earliest_start(self) -> Optional[int]:
+    def earliest_start(self) -> int:
         return self._earliest_start
 
     @property
-    def latest_start(self) -> Optional[int]:
+    def latest_start(self) -> int:
         return self._latest_start
 
     @property
-    def earliest_end(self) -> Optional[int]:
+    def earliest_end(self) -> int:
         return self._earliest_end
 
     @property
-    def latest_end(self) -> Optional[int]:
+    def latest_end(self) -> int:
         return self._latest_end
 
     @property

--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -99,31 +99,31 @@ def task_graph(
                     m.add(expr)
 
 
-def alternative_constraints(
+def select_one_task_alternative(
     m: CpModel,
     data: ProblemData,
     task_vars: TaskVars,
     assign_vars: AssignmentVars,
 ):
     """
-    Creates the alternative constraints for the tasks, ensuring that each
-    task is scheduled on exactly one machine.
+    Selects one optional (assignment) interval for each task, ensuring that
+    each task is scheduled on exactly one machine.
     """
     for task in range(data.num_tasks):
         presences = []
 
         for machine in data.task2machines[task]:
             main = task_vars[task]
-            assign = assign_vars[task, machine]
-            is_present = assign.is_present
+            opt = assign_vars[task, machine]
+            is_present = opt.is_present
             presences.append(is_present)
 
-            # Link each optional interval variable with the main variable.
-            m.add(main.start == assign.start).only_enforce_if(is_present)
-            m.add(main.duration == assign.duration).only_enforce_if(is_present)
-            m.add(main.end == assign.end).only_enforce_if(is_present)
+            # Sync each optional interval variable with the main variable.
+            m.add(main.start == opt.start).only_enforce_if(is_present)
+            m.add(main.duration == opt.duration).only_enforce_if(is_present)
+            m.add(main.end == opt.end).only_enforce_if(is_present)
 
-        # Select exactly one machine for the task.
+        # Select exactly one optional interval variable for each task.
         m.add_exactly_one(presences)
 
 

--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -139,24 +139,6 @@ def no_overlap_constraints(
             m.add_no_overlap([var.interval for var in seq_vars[machine].tasks])
 
 
-def processing_time_constraints(
-    m: CpModel, data: ProblemData, assign_vars: AssignmentVars
-):
-    """
-    Creates the processing time constraints for the task variables, ensuring
-    that the duration of the task on the machine is the processing time.
-    If the task allows for variable duration, the duration could be longer
-    than the processing time due to blocking.
-    """
-    for (task, machine), var in assign_vars.items():
-        duration = data.processing_times[machine, task]
-
-        if data.tasks[task].fixed_duration:
-            m.add(var.duration == duration)
-        else:
-            m.add(var.duration >= duration)
-
-
 def setup_time_constraints(
     m: CpModel, data: ProblemData, seq_vars: SequenceVars
 ):

--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -13,18 +13,6 @@ AssignmentVars = dict[tuple[int, int], AssignmentVar]
 SequenceVars = list[SequenceVar]
 
 
-def job_data_constraints(m: CpModel, data: ProblemData, job_vars: JobVars):
-    """
-    Creates the constraints that ensure that the job variables are consistent
-    with the job data.
-    """
-    for job_data, job_var in zip(data.jobs, job_vars):
-        m.add(job_var.start >= job_data.release_date)
-
-        if job_data.deadline is not None:
-            m.add(job_var.end <= job_data.deadline)
-
-
 def job_task_constraints(
     m: CpModel, data: ProblemData, job_vars: JobVars, task_vars: TaskVars
 ):

--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -127,9 +127,7 @@ def select_one_task_alternative(
         m.add_exactly_one(presences)
 
 
-def no_overlap_constraints(
-    m: CpModel, data: ProblemData, seq_vars: SequenceVars
-):
+def no_overlap_machines(m: CpModel, data: ProblemData, seq_vars: SequenceVars):
     """
     Creates the no overlap constraints for machines, ensuring that no two
     intervals in a sequence variable are overlapping.
@@ -139,12 +137,12 @@ def no_overlap_constraints(
             m.add_no_overlap([var.interval for var in seq_vars[machine].tasks])
 
 
-def setup_time_constraints(
+def activate_setup_times(
     m: CpModel, data: ProblemData, seq_vars: SequenceVars
 ):
     """
-    Actives the sequence variables for machines that have setup times. The
-    ``circuit_constraints`` function will in turn add the constraints to the
+    Activates the sequence variables for machines that have setup times. The
+    ``circuit_constraints`` function will in turn add constraints to the
     CP-SAT model to enforce setup times.
     """
     for machine in range(data.num_machines):
@@ -154,9 +152,9 @@ def setup_time_constraints(
             seq_vars[machine].activate()
 
 
-def circuit_constraints(m: CpModel, data: ProblemData, seq_vars: SequenceVars):
+def enforce_circuit(m: CpModel, data: ProblemData, seq_vars: SequenceVars):
     """
-    Creates the circuit constraints for each machine, ensuring that the
+    Enforce the circuit constraints for each machine, ensuring that the
     sequencing constraints are respected.
     """
     for machine in range(data.num_machines):

--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -13,12 +13,11 @@ AssignmentVars = dict[tuple[int, int], AssignmentVar]
 SequenceVars = list[SequenceVar]
 
 
-def job_task_constraints(
+def job_spans_tasks(
     m: CpModel, data: ProblemData, job_vars: JobVars, task_vars: TaskVars
 ):
     """
-    Creates the constraints that ensure that the job variables govern the
-    related task variables.
+    Ensures that the job variables span the related task variables.
     """
     for job in range(data.num_jobs):
         job_var = job_vars[job]

--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -43,24 +43,6 @@ def job_task_constraints(
             m.add(var.start >= data.jobs[job].release_date)
 
 
-def task_constraints(m: CpModel, data: ProblemData, task_vars: TaskVars):
-    """
-    Creates constraints on the task variables.
-    """
-    for task_data, var in zip(data.tasks, task_vars):
-        if task_data.earliest_start is not None:
-            m.add(var.start >= task_data.earliest_start)
-
-        if task_data.latest_start is not None:
-            m.add(var.start <= task_data.latest_start)
-
-        if task_data.earliest_end is not None:
-            m.add(var.end >= task_data.earliest_end)
-
-        if task_data.latest_end is not None:
-            m.add(var.end <= task_data.latest_end)
-
-
 def task_graph(
     m: CpModel,
     data: ProblemData,

--- a/pyjobshop/ortools/create_model.py
+++ b/pyjobshop/ortools/create_model.py
@@ -5,7 +5,7 @@ from pyjobshop.ProblemData import ProblemData
 from .constraints import (
     alternative_constraints,
     circuit_constraints,
-    job_task_constraints,
+    job_spans_tasks,
     no_overlap_constraints,
     processing_time_constraints,
     setup_time_constraints,
@@ -60,7 +60,7 @@ def create_model(
     else:
         raise ValueError(f"Unknown objective: {data.objective}")
 
-    job_task_constraints(model, data, job_vars, task_vars)
+    job_spans_tasks(model, data, job_vars, task_vars)
     alternative_constraints(model, data, task_vars, assign_vars)
     no_overlap_constraints(model, data, seq_vars)
     processing_time_constraints(model, data, assign_vars)

--- a/pyjobshop/ortools/create_model.py
+++ b/pyjobshop/ortools/create_model.py
@@ -3,11 +3,11 @@ from ortools.sat.python.cp_model import CpModel
 from pyjobshop.ProblemData import ProblemData
 
 from .constraints import (
-    alternative_constraints,
     circuit_constraints,
     job_spans_tasks,
     no_overlap_constraints,
     processing_time_constraints,
+    select_one_task_alternative,
     setup_time_constraints,
     task_graph,
 )
@@ -61,7 +61,7 @@ def create_model(
         raise ValueError(f"Unknown objective: {data.objective}")
 
     job_spans_tasks(model, data, job_vars, task_vars)
-    alternative_constraints(model, data, task_vars, assign_vars)
+    select_one_task_alternative(model, data, task_vars, assign_vars)
     no_overlap_constraints(model, data, seq_vars)
     processing_time_constraints(model, data, assign_vars)
     setup_time_constraints(model, data, seq_vars)

--- a/pyjobshop/ortools/create_model.py
+++ b/pyjobshop/ortools/create_model.py
@@ -6,7 +6,6 @@ from .constraints import (
     circuit_constraints,
     job_spans_tasks,
     no_overlap_constraints,
-    processing_time_constraints,
     select_one_task_alternative,
     setup_time_constraints,
     task_graph,
@@ -63,7 +62,6 @@ def create_model(
     job_spans_tasks(model, data, job_vars, task_vars)
     select_one_task_alternative(model, data, task_vars, assign_vars)
     no_overlap_constraints(model, data, seq_vars)
-    processing_time_constraints(model, data, assign_vars)
     setup_time_constraints(model, data, seq_vars)
     task_graph(model, data, task_vars, assign_vars, seq_vars)
 

--- a/pyjobshop/ortools/create_model.py
+++ b/pyjobshop/ortools/create_model.py
@@ -3,11 +3,11 @@ from ortools.sat.python.cp_model import CpModel
 from pyjobshop.ProblemData import ProblemData
 
 from .constraints import (
-    circuit_constraints,
+    activate_setup_times,
+    enforce_circuit,
     job_spans_tasks,
-    no_overlap_constraints,
+    no_overlap_machines,
     select_one_task_alternative,
-    setup_time_constraints,
     task_graph,
 )
 from .objectives import (
@@ -61,11 +61,11 @@ def create_model(
 
     job_spans_tasks(model, data, job_vars, task_vars)
     select_one_task_alternative(model, data, task_vars, assign_vars)
-    no_overlap_constraints(model, data, seq_vars)
-    setup_time_constraints(model, data, seq_vars)
+    no_overlap_machines(model, data, seq_vars)
+    activate_setup_times(model, data, seq_vars)
     task_graph(model, data, task_vars, assign_vars, seq_vars)
 
     # Must be called last to ensure that sequence constriants are enforced!
-    circuit_constraints(model, data, seq_vars)
+    enforce_circuit(model, data, seq_vars)
 
     return model, assign_vars

--- a/pyjobshop/ortools/create_model.py
+++ b/pyjobshop/ortools/create_model.py
@@ -5,7 +5,6 @@ from pyjobshop.ProblemData import ProblemData
 from .constraints import (
     alternative_constraints,
     circuit_constraints,
-    job_data_constraints,
     job_task_constraints,
     no_overlap_constraints,
     processing_time_constraints,
@@ -61,7 +60,6 @@ def create_model(
     else:
         raise ValueError(f"Unknown objective: {data.objective}")
 
-    job_data_constraints(model, data, job_vars)
     job_task_constraints(model, data, job_vars, task_vars)
     alternative_constraints(model, data, task_vars, assign_vars)
     no_overlap_constraints(model, data, seq_vars)

--- a/pyjobshop/ortools/create_model.py
+++ b/pyjobshop/ortools/create_model.py
@@ -10,7 +10,6 @@ from .constraints import (
     no_overlap_constraints,
     processing_time_constraints,
     setup_time_constraints,
-    task_constraints,
     task_graph,
 )
 from .objectives import (
@@ -64,7 +63,6 @@ def create_model(
 
     job_data_constraints(model, data, job_vars)
     job_task_constraints(model, data, job_vars, task_vars)
-    task_constraints(model, data, task_vars)
     alternative_constraints(model, data, task_vars, assign_vars)
     no_overlap_constraints(model, data, seq_vars)
     processing_time_constraints(model, data, assign_vars)

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -168,17 +168,13 @@ def task_variables(m: CpModel, data: ProblemData) -> list[TaskVar]:
         tasks.append(task_var)
 
         # Impose task data constraints.
-        if task.earliest_start is not None:
-            m.add(task_var.start >= task.earliest_start)
+        m.add(task_var.start >= task.earliest_start)
 
-        if task.latest_start is not None:
-            m.add(task_var.start <= task.latest_start)
+        m.add(task_var.start <= task.latest_start)
 
-        if task.earliest_end is not None:
-            m.add(task_var.end >= task.earliest_end)
+        m.add(task_var.end >= task.earliest_end)
 
-        if task.latest_end is not None:
-            m.add(task_var.end <= task.latest_end)
+        m.add(task_var.end <= task.latest_end)
 
     return tasks
 

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -106,7 +106,14 @@ def job_variables(m: CpModel, data: ProblemData) -> list[JobVar]:
         interval_var = m.NewIntervalVar(
             start_var, duration_var, end_var, f"interval_{job}"
         )
-        jobs.append(JobVar(interval_var, start_var, duration_var, end_var))
+        job_var = JobVar(interval_var, start_var, duration_var, end_var)
+        jobs.append(job_var)
+
+        # Impose job data constraints.
+        m.add(job_var.start >= job.release_date)
+
+        if job.deadline is not None:
+            m.add(job_var.end <= job.deadline)
 
     return jobs
 

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -8,6 +8,21 @@ from pyjobshop.ProblemData import ProblemData
 
 @dataclass
 class JobVar:
+    """
+    Variables that represent a job in the problem.
+
+    Parameters
+    ----------
+    interval
+        The interval variable representing the job.
+    start
+        The start variable time of the interval.
+    duration
+        The duration variable of the interval.
+    end
+        The end variable time of the interval.
+    """
+
     interval: IntervalVar
     start: IntVar
     duration: IntVar
@@ -16,6 +31,21 @@ class JobVar:
 
 @dataclass
 class TaskVar:
+    """
+    Variables that represent a task in the problem.
+
+    Parameters
+    ----------
+    interval
+        The interval variable representing the task.
+    start
+        The start variable time of the interval.
+    duration
+        The duration variable of the interval.
+    end
+        The end variable time of the interval.
+    """
+
     interval: IntervalVar
     start: IntVar
     duration: IntVar

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -127,7 +127,21 @@ def task_variables(m: CpModel, data: ProblemData) -> list[TaskVar]:
         interval_var = m.NewIntervalVar(
             start_var, duration_var, end_var, f"interval_{task}"
         )
-        tasks.append(TaskVar(interval_var, start_var, duration_var, end_var))
+        task_var = TaskVar(interval_var, start_var, duration_var, end_var)
+        tasks.append(task_var)
+
+        # Impose task data constraints.
+        if task.earliest_start is not None:
+            m.add(task_var.start >= task.earliest_start)
+
+        if task.latest_start is not None:
+            m.add(task_var.start <= task.latest_start)
+
+        if task.earliest_end is not None:
+            m.add(task_var.end >= task.earliest_end)
+
+        if task.latest_end is not None:
+            m.add(task_var.end <= task.latest_end)
 
     return tasks
 

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -194,9 +194,12 @@ def assignment_variables(
     for (machine, task), duration in data.processing_times.items():
         name = f"A{task}_{machine}"
         start_var = m.new_int_var(0, data.planning_horizon, f"{name}_start")
-        duration_var = m.new_int_var(
-            0, data.planning_horizon, f"{name}_duration"
-        )
+
+        duration = data.processing_times[machine, task]
+        lb = duration
+        ub = lb if data.tasks[task].fixed_duration else data.planning_horizon
+        duration_var = m.new_int_var(lb, ub, f"{name}_duration")
+
         end_var = m.new_int_var(0, data.planning_horizon, f"{name}_start")
         is_present_var = m.new_bool_var(f"{name}_is_present")
         interval_var = m.new_optional_interval_var(
@@ -214,8 +217,6 @@ def assignment_variables(
             end=end_var,
             is_present=is_present_var,
         )
-
-        m.add(duration_var >= duration)
 
     return variables
 

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -16,11 +16,11 @@ class JobVar:
     interval
         The interval variable representing the job.
     start
-        The start variable time of the interval.
+        The start time variable of the interval.
     duration
         The duration variable of the interval.
     end
-        The end variable time of the interval.
+        The end time variable of the interval.
     """
 
     interval: IntervalVar
@@ -39,11 +39,11 @@ class TaskVar:
     interval
         The interval variable representing the task.
     start
-        The start variable time of the interval.
+        The start time variable of the interval.
     duration
         The duration variable of the interval.
     end
-        The end variable time of the interval.
+        The end time variable of the interval.
     """
 
     interval: IntervalVar
@@ -64,11 +64,11 @@ class AssignmentVar:
     interval
         The interval variable representing the assignment of the task.
     start
-        The start variable time of the interval.
+        The start time variable of the interval.
     duration
         The duration variable of the interval.
     end
-        The end variable time of the interval.
+        The end time variable of the interval.
     is_present
         The boolean variable indicating whether the interval is present.
     """
@@ -124,59 +124,68 @@ def job_variables(m: CpModel, data: ProblemData) -> list[JobVar]:
     """
     Creates an interval variable for each job.
     """
-    jobs = []
+    variables = []
 
     for job in data.jobs:
         name = f"J{job}"
-        start_var = m.new_int_var(0, data.planning_horizon, f"{name}_start")
-        duration_var = m.new_int_var(
-            0, data.planning_horizon, f"{name}_duration"
+        start = m.new_int_var(
+            lb=job.release_date,
+            ub=data.planning_horizon,
+            name=f"{name}_start",
         )
-        end_var = m.new_int_var(0, data.planning_horizon, f"{name}_end")
-        interval_var = m.NewIntervalVar(
-            start_var, duration_var, end_var, f"interval_{job}"
+        duration = m.new_int_var(
+            lb=0,
+            ub=min(job.deadline - job.release_date, data.planning_horizon),
+            name=f"{name}_duration",
         )
-        job_var = JobVar(interval_var, start_var, duration_var, end_var)
-        jobs.append(job_var)
+        end = m.new_int_var(
+            lb=0,
+            ub=min(job.deadline, data.planning_horizon),
+            name=f"{name}_end",
+        )
+        interval = m.NewIntervalVar(start, duration, end, f"{name}_interval")
+        variables.append(JobVar(interval, start, duration, end))
 
-        # Impose job data constraints.
-        m.add(job_var.start >= job.release_date)
-
-        if job.deadline is not None:
-            m.add(job_var.end <= job.deadline)
-
-    return jobs
+    return variables
 
 
 def task_variables(m: CpModel, data: ProblemData) -> list[TaskVar]:
     """
     Creates an interval variable for each task.
     """
-    tasks = []
+    variables = []
 
-    for task in data.tasks:
+    # Improve duration bounds using processing times.
+    min_durations: dict[int, int] = defaultdict(lambda: data.planning_horizon)
+    max_durations: dict[int, int] = defaultdict(lambda: 0)
+
+    for (_, task_idx), duration in data.processing_times.items():
+        min_durations[task_idx] = min(min_durations[task_idx], duration)
+        max_durations[task_idx] = max(max_durations[task_idx], duration)
+
+    for idx, task in enumerate(data.tasks):
         name = f"T{task}"
-        start_var = m.new_int_var(0, data.planning_horizon, f"{name}_start")
-        duration_var = m.new_int_var(
-            0, data.planning_horizon, f"{name}_duration"
+        start = m.new_int_var(
+            lb=task.earliest_start,
+            ub=min(task.latest_start, data.planning_horizon),
+            name=f"{name}_start",
         )
-        end_var = m.new_int_var(0, data.planning_horizon, f"{name}_end")
-        interval_var = m.NewIntervalVar(
-            start_var, duration_var, end_var, f"interval_{task}"
+        duration = m.new_int_var(
+            lb=min_durations[idx],
+            ub=max_durations[idx]
+            if task.fixed_duration
+            else data.planning_horizon,  # unbounded if variable duration
+            name=f"{name}_duration",
         )
-        task_var = TaskVar(interval_var, start_var, duration_var, end_var)
-        tasks.append(task_var)
+        end = m.new_int_var(
+            lb=task.earliest_end,
+            ub=min(task.latest_end, data.planning_horizon),
+            name=f"{name}_end",
+        )
+        interval = m.NewIntervalVar(start, duration, end, f"interval_{task}")
+        variables.append(TaskVar(interval, start, duration, end))
 
-        # Impose task data constraints.
-        m.add(task_var.start >= task.earliest_start)
-
-        m.add(task_var.start <= task.latest_start)
-
-        m.add(task_var.end >= task.earliest_end)
-
-        m.add(task_var.end <= task.latest_end)
-
-    return tasks
+    return variables
 
 
 def assignment_variables(
@@ -187,31 +196,36 @@ def assignment_variables(
     """
     variables = {}
 
-    for (machine, task), duration in data.processing_times.items():
+    for (machine_idx, task_idx), proc_time in data.processing_times.items():
+        task = data.tasks[task_idx]
+        machine = data.machines[machine_idx]
         name = f"A{task}_{machine}"
-        start_var = m.new_int_var(0, data.planning_horizon, f"{name}_start")
-
-        duration = data.processing_times[machine, task]
-        lb = duration
-        ub = lb if data.tasks[task].fixed_duration else data.planning_horizon
-        duration_var = m.new_int_var(lb, ub, f"{name}_duration")
-
-        end_var = m.new_int_var(0, data.planning_horizon, f"{name}_start")
-        is_present_var = m.new_bool_var(f"{name}_is_present")
-        interval_var = m.new_optional_interval_var(
-            start_var,
-            duration_var,
-            end_var,
-            is_present_var,
-            f"{name}_interval",
+        start = m.new_int_var(
+            lb=task.earliest_start,
+            ub=min(task.latest_start, data.planning_horizon),
+            name=f"{name}_start",
         )
-        variables[task, machine] = AssignmentVar(
-            task_idx=task,
-            interval=interval_var,
-            start=start_var,
-            duration=duration_var,
-            end=end_var,
-            is_present=is_present_var,
+        duration = m.new_int_var(
+            lb=proc_time,
+            ub=proc_time if task.fixed_duration else data.planning_horizon,
+            name=f"{name}_duration",
+        )
+        end = m.new_int_var(
+            lb=task.earliest_end,
+            ub=min(task.latest_end, data.planning_horizon),
+            name=f"{name}_start",
+        )
+        is_present = m.new_bool_var(f"{name}_is_present")
+        interval = m.new_optional_interval_var(
+            start, duration, end, is_present, f"{name}_interval"
+        )
+        variables[task_idx, machine_idx] = AssignmentVar(
+            task_idx=task_idx,
+            interval=interval,
+            start=start,
+            duration=duration,
+            end=end,
+            is_present=is_present,
         )
 
     return variables
@@ -228,14 +242,10 @@ def sequence_variables(
     """
     variables = []
 
-    # Group the assignment variables by machine.
-    machine2tasks = defaultdict(list)
-    for (_, machine), var in assign.items():
-        machine2tasks[machine].append(var)
-
     for machine in range(data.num_machines):
-        tasks = machine2tasks[machine]
-        num_tasks = len(tasks)
+        tasks = data.machine2tasks[machine]
+        assign_vars = [assign[task, machine] for task in tasks]
+        num_tasks = len(assign_vars)
 
         # Start and end literals define whether the corresponding interval
         # is first or last in the sequence, respectively.
@@ -252,6 +262,6 @@ def sequence_variables(
             for j in range(num_tasks)
         }
 
-        variables.append(SequenceVar(tasks, starts, ends, ranks, arcs))
+        variables.append(SequenceVar(assign_vars, starts, ends, ranks, arcs))
 
     return variables

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal, assert_raises
@@ -110,10 +108,10 @@ def test_task_attributes():
     # Also test that default values are set correctly.
     task = Task()
 
-    assert_equal(task.earliest_start, None)
-    assert_equal(task.latest_start, None)
-    assert_equal(task.earliest_end, None)
-    assert_equal(task.latest_end, None)
+    assert_equal(task.earliest_start, 0)
+    assert_equal(task.latest_start, MAX_VALUE)
+    assert_equal(task.earliest_end, 0)
+    assert_equal(task.latest_end, MAX_VALUE)
     assert_equal(task.fixed_duration, True)
     assert_equal(task.name, "")
 
@@ -121,15 +119,15 @@ def test_task_attributes():
 @pytest.mark.parametrize(
     "earliest_start, latest_start, earliest_end, latest_end",
     [
-        (1, 0, None, None),  # earliest_start > latest_start
-        (None, None, 1, 0),  # earliest_end > latest_end
+        (1, 0, 0, 0),  # earliest_start > latest_start
+        (0, 0, 1, 0),  # earliest_end > latest_end
     ],
 )
 def test_task_attributes_raises_invalid_parameters(
-    earliest_start: Optional[int],
-    latest_start: Optional[int],
-    earliest_end: Optional[int],
-    latest_end: Optional[int],
+    earliest_start: int,
+    latest_start: int,
+    earliest_end: int,
+    latest_end: int,
 ):
     """
     Tests that an error is raised when invalid parameters are passed to the

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -36,8 +36,8 @@ def test_job_default_attributes():
 
     assert_equal(job.weight, 1)
     assert_equal(job.release_date, 0)
+    assert_equal(job.deadline, MAX_VALUE)
     assert_equal(job.due_date, None)
-    assert_equal(job.deadline, None)
     assert_equal(job.name, "")
 
 
@@ -46,13 +46,13 @@ def test_job_default_attributes():
     [
         (-1, 0, 0, 0, ""),  # weight < 0
         (0, -1, 0, 0, ""),  # release_date < 0
-        (0, 0, -1, 0, ""),  # due_date < 0
-        (0, 0, 0, -1, ""),  # deadline < 0
+        (0, 0, -1, 0, ""),  # deadline < 0
         (0, 10, 0, 0, ""),  # release_date > deadline
+        (0, 0, 0, -1, ""),  # due_date < 0
     ],
 )
 def test_job_attributes_raises_invalid_parameters(
-    weight: int, release_date: int, due_date: int, deadline: int, name: str
+    weight: int, release_date: int, deadline: int, due_date: int, name: str
 ):
     """
     Tests that a ValueError is raised when invalid parameters are passed to
@@ -62,8 +62,8 @@ def test_job_attributes_raises_invalid_parameters(
         Job(
             weight=weight,
             release_date=release_date,
-            due_date=due_date,
             deadline=deadline,
+            due_date=due_date,
             name=name,
         )
 


### PR DESCRIPTION
This PR refactors the implementation of CP models. In particular:
- Constraints that directly apply to the corresponding variable (e.g., release date for job) are moved to the variable instantiation functions. 
- Constraints are renamed to reflect the result better.
- Turn `job.deadline` into a numerical value with a sensible default, as well as `operation.start` and `operation.end` times.