### PR TITLE
[CP Optimizer] Refactor implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 # PyJobShop
 [![PyPI](https://img.shields.io/pypi/v/PyJobShop?style=flat-square)](https://pypi.org/project/pyjobshop/)
-[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/leonlan/PyJobShop/)
-[![CI](https://img.shields.io/github/actions/workflow/status/leonlan/PyJobShop/.github%2Fworkflows%2FCI.yml?style=flat-square)](https://github.com/leonlan/PyJobShop/)
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/PyJobShop/PyJobShop/)
+[![CI](https://img.shields.io/github/actions/workflow/status/PyJobShop/PyJobShop/.github%2Fworkflows%2FCI.yml?style=flat-square)](https://github.com/PyJobShop/PyJobShop/)
 [![DOC](https://img.shields.io/readthedocs/pyjobshop?style=flat-square)](https://pyjobshop.readthedocs.io/)
-[![Codecov](https://img.shields.io/codecov/c/github/leonlan/PyJobShop?style=flat-square)](https://app.codecov.io/gh/leonlan/PyJobShop/)
+[![Codecov](https://img.shields.io/codecov/c/github/PyJobShop/PyJobShop?style=flat-square)](https://app.codecov.io/gh/PyJobShop/PyJobShop/)
 
 PyJobShop is a package for implementing scheduling models in Python.
 It supports the classically known *flexible job shop problem* (FJSP) and many of its extensions such as arbitrary precedence relations, sequence-dependent setup times, and many more!

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -265,8 +265,7 @@ class ProblemData:
         The first dimension of the array is indexed by the machine index. The
         last two dimensions of the array are indexed by task indices.
     planning_horizon
-        The planning horizon value. Default is None, meaning that the planning
-        horizon is unbounded.
+        The planning horizon value. Default ``MAX_VALUE``.
     objective
         The objective function to be minimized. Default is the makespan.
     """
@@ -327,7 +326,7 @@ class ProblemData:
             msg = "Setup times shape not (num_machines, num_tasks, num_tasks)."
             raise ValueError(msg)
 
-        if self.planning_horizon is not None and self.planning_horizon < 0:
+        if self.planning_horizon < 0:
             raise ValueError("Planning horizon must be non-negative.")
 
         if self.objective in [Objective.TARDY_JOBS, Objective.TOTAL_TARDINESS]:

--- a/pyjobshop/cpoptimizer/constraints.py
+++ b/pyjobshop/cpoptimizer/constraints.py
@@ -12,22 +12,6 @@ AssignmentVars = dict[tuple[int, int], CpoIntervalVar]
 SeqVars = list[CpoSequenceVar]
 
 
-def select_one_task_alternative(
-    m: CpoModel,
-    data: ProblemData,
-    task_vars: TaskVars,
-    assign_vars: AssignmentVars,
-):
-    """
-    Selects one optional (assignment) interval for each task, ensuring that
-    each task is scheduled on exactly one machine.
-    """
-    for task in range(data.num_tasks):
-        machines = data.task2machines[task]
-        optional = [assign_vars[task, machine] for machine in machines]
-        m.add(m.alternative(task_vars[task], optional))
-
-
 def job_spans_tasks(
     m: CpoModel, data: ProblemData, job_vars: JobVars, task_vars: TaskVars
 ):
@@ -64,6 +48,22 @@ def no_overlap_and_setup_times(
             m.add(m.no_overlap(seq_vars[machine]))
         else:
             m.add(m.no_overlap(seq_vars[machine], setups))
+
+
+def select_one_task_alternative(
+    m: CpoModel,
+    data: ProblemData,
+    task_vars: TaskVars,
+    assign_vars: AssignmentVars,
+):
+    """
+    Selects one optional (assignment) interval for each task, ensuring that
+    each task is scheduled on exactly one machine.
+    """
+    for task in range(data.num_tasks):
+        machines = data.task2machines[task]
+        optional = [assign_vars[task, machine] for machine in machines]
+        m.add(m.alternative(task_vars[task], optional))
 
 
 def task_graph(

--- a/pyjobshop/cpoptimizer/constraints.py
+++ b/pyjobshop/cpoptimizer/constraints.py
@@ -65,24 +65,6 @@ def no_overlap_and_setup_time_constraints(
             m.add(m.no_overlap(seq_vars[machine], setups))
 
 
-def planning_horizon_constraints(
-    m: CpoModel,
-    data: ProblemData,
-    job_vars: JobVars,
-    assign_vars: AssignmentVars,
-    task_vars: TaskVars,
-):
-    """
-    Creates the planning horizon constraints for the interval variables,
-    ensuring that the end of each interval is within the planning horizon.
-    """
-    if data.planning_horizon is None:
-        return []  # unbounded planning horizon
-
-    for vars in [job_vars, assign_vars.values(), task_vars]:
-        m.add([m.end_of(var) <= data.planning_horizon for var in vars])
-
-
 def task_graph(
     m: CpoModel,
     data: ProblemData,

--- a/pyjobshop/cpoptimizer/constraints.py
+++ b/pyjobshop/cpoptimizer/constraints.py
@@ -41,12 +41,13 @@ def job_spans_tasks(
         m.add(m.span(job_var, related_task_vars))
 
 
-def no_overlap_and_setup_time_constraints(
+def no_overlap_and_setup_times(
     m: CpoModel, data: ProblemData, seq_vars: SeqVars
 ):
     """
     Creates the no-overlap constraints for machines, ensuring that no two
-    intervals in a sequence variable are overlapping.
+    intervals in a sequence variable are overlapping. If setup times are
+    available, the setup times are enforced as well.
     """
     # Assumption: the interval variables in the sequence variable
     # are ordered in the same way as the tasks in machine2tasks.

--- a/pyjobshop/cpoptimizer/constraints.py
+++ b/pyjobshop/cpoptimizer/constraints.py
@@ -1,7 +1,7 @@
 from itertools import product
 
 import numpy as np
-from docplex.cp.expression import CpoExpr, CpoIntervalVar, CpoSequenceVar
+from docplex.cp.expression import CpoIntervalVar, CpoSequenceVar
 from docplex.cp.model import CpoModel
 
 from pyjobshop.ProblemData import ProblemData
@@ -12,75 +12,42 @@ AssignmentVars = dict[tuple[int, int], CpoIntervalVar]
 SeqVars = list[CpoSequenceVar]
 
 
-def alternative_constraints(
+def select_one_task_alternative(
     m: CpoModel,
     data: ProblemData,
     task_vars: TaskVars,
     assign_vars: AssignmentVars,
-) -> list[CpoExpr]:
+):
     """
-    Creates the alternative constraints for the tasks, ensuring that each
-    task is scheduled on exactly one machine.
+    Selects one optional (assignment) interval for each task, ensuring that
+    each task is scheduled on exactly one machine.
     """
-    constraints = []
-
     for task in range(data.num_tasks):
         machines = data.task2machines[task]
         optional = [assign_vars[task, machine] for machine in machines]
-        constraints.append(m.alternative(task_vars[task], optional))
-
-    return constraints
+        m.add(m.alternative(task_vars[task], optional))
 
 
-def job_data_constraints(
-    m: CpoModel, data: ProblemData, job_vars: JobVars
-) -> list[CpoExpr]:
-    """
-    Creates constraints related to the job data.
-    """
-    constraints = []
-
-    for job_data, job_var in zip(data.jobs, job_vars):
-        constraints.append(m.start_of(job_var) >= job_data.release_date)
-
-        if job_data.deadline is not None:
-            constraints.append(m.end_of(job_var) <= job_data.deadline)
-
-    return constraints
-
-
-def job_task_constraints(
+def job_spans_tasks(
     m: CpoModel, data: ProblemData, job_vars: JobVars, task_vars: TaskVars
-) -> list[CpoExpr]:
+):
     """
-    Creates the constraints that ensure that the job variables govern the
-    related task variables.
+    Ensures that the job variables span the related task variables.
     """
-    constraints = []
-
     for job in range(data.num_jobs):
         job_var = job_vars[job]
         related_task_vars = [task_vars[task] for task in data.job2tasks[job]]
 
-        constraints.append(m.span(job_var, related_task_vars))
-
-        for task_var in related_task_vars:
-            constraints.append(
-                m.start_of(task_var) >= data.jobs[job].release_date
-            )
-
-    return constraints
+        m.add(m.span(job_var, related_task_vars))
 
 
 def no_overlap_and_setup_time_constraints(
     m: CpoModel, data: ProblemData, seq_vars: SeqVars
-) -> list[CpoExpr]:
+):
     """
     Creates the no-overlap constraints for machines, ensuring that no two
     intervals in a sequence variable are overlapping.
     """
-    constraints = []
-
     # Assumption: the interval variables in the sequence variable
     # are ordered in the same way as the tasks in machine2tasks.
     for machine in range(data.num_machines):
@@ -93,33 +60,9 @@ def no_overlap_and_setup_time_constraints(
         setups = data.setup_times[machine, :, :][np.ix_(tasks, tasks)]
 
         if np.all(setups == 0):  # No setup times for this machine.
-            constraints.append(m.no_overlap(seq_vars[machine]))
+            m.add(m.no_overlap(seq_vars[machine]))
         else:
-            constraints.append(m.no_overlap(seq_vars[machine], setups))
-
-    return constraints
-
-
-def task_constraints(
-    m: CpoModel, data: ProblemData, task_vars: TaskVars
-) -> list[CpoExpr]:
-    """
-    Creates constraints on the task variables.
-    """
-    for task_data, var in zip(data.tasks, task_vars):
-        if task_data.earliest_start is not None:
-            var.set_start_min(task_data.earliest_start)
-
-        if task_data.latest_start is not None:
-            var.set_start_max(task_data.latest_start)
-
-        if task_data.earliest_end is not None:
-            var.set_end_min(task_data.earliest_end)
-
-        if task_data.latest_end is not None:
-            var.set_end_max(task_data.latest_end)
-
-    return []  # no constraints because we use setters
+            m.add(m.no_overlap(seq_vars[machine], setups))
 
 
 def planning_horizon_constraints(
@@ -128,7 +71,7 @@ def planning_horizon_constraints(
     job_vars: JobVars,
     assign_vars: AssignmentVars,
     task_vars: TaskVars,
-) -> list[CpoExpr]:
+):
     """
     Creates the planning horizon constraints for the interval variables,
     ensuring that the end of each interval is within the planning horizon.
@@ -136,48 +79,26 @@ def planning_horizon_constraints(
     if data.planning_horizon is None:
         return []  # unbounded planning horizon
 
-    constraints = []
-
     for vars in [job_vars, assign_vars.values(), task_vars]:
-        constraints += [m.end_of(var) <= data.planning_horizon for var in vars]
-
-    return constraints
+        m.add([m.end_of(var) <= data.planning_horizon for var in vars])
 
 
-def processing_time_constraints(
-    m: CpoModel, data: ProblemData, assign_vars: AssignmentVars
-) -> list[CpoExpr]:
-    """
-    Creates the processing time constraints for the task variables, ensuring
-    that the duration of the task on the machine is the processing time.
-    If the task allows for variable duration, the duration could be longer
-    than the processing time due to blocking.
-    """
-    for (task, machine), var in assign_vars.items():
-        duration = data.processing_times[machine, task]
-
-        if data.tasks[task].fixed_duration:
-            var.set_size(duration)
-        else:
-            var.set_size_min(duration)  # at least duration
-
-    return []  # no constraints because we use setters
-
-
-def task_graph_constraints(
+def task_graph(
     m: CpoModel,
     data: ProblemData,
     task_vars: TaskVars,
     assign_vars: AssignmentVars,
     seq_vars: SeqVars,
-) -> list[CpoExpr]:
-    constraints = []
-
-    for (idx1, idx2), constraints_ in data.constraints.items():
+):
+    """
+    Creates constraints based on the task graph, ensuring that the
+    tasks are scheduled according to the graph.
+    """
+    for (idx1, idx2), constraints in data.constraints.items():
         task1 = task_vars[idx1]
         task2 = task_vars[idx2]
 
-        for constraint in constraints_:
+        for constraint in constraints:
             if constraint == "start_at_start":
                 expr = m.start_at_start(task1, task2)
             elif constraint == "start_at_end":
@@ -197,7 +118,7 @@ def task_graph_constraints(
             else:
                 continue
 
-            constraints.append(expr)
+            m.add(expr)
 
     # Separately handle assignment related constraints for efficiency.
     for machine, tasks in enumerate(data.machine2tasks):
@@ -218,6 +139,4 @@ def task_graph_constraints(
                 elif constraint == "different_unit":
                     expr = m.presence_of(var1) != m.presence_of(var2)
 
-                constraints.append(expr)
-
-    return constraints
+                m.add(expr)

--- a/pyjobshop/cpoptimizer/create_model.py
+++ b/pyjobshop/cpoptimizer/create_model.py
@@ -44,13 +44,13 @@ def create_model(data: ProblemData) -> CpoModel:
     seq_vars = sequence_variables(model, data, assign_vars)
 
     if data.objective == "makespan":
-        model.add(makespan(model, data, task_vars))
+        makespan(model, data, task_vars)
     elif data.objective == "tardy_jobs":
-        model.add(tardy_jobs(model, data, job_vars))
+        tardy_jobs(model, data, job_vars)
     elif data.objective == "total_tardiness":
-        model.add(total_tardiness(model, data, job_vars))
+        total_tardiness(model, data, job_vars)
     elif data.objective == "total_completion_time":
-        model.add(total_completion_time(model, data, job_vars))
+        total_completion_time(model, data, job_vars)
     else:
         raise ValueError(f"Unknown objective: {data.objective}")
 

--- a/pyjobshop/cpoptimizer/create_model.py
+++ b/pyjobshop/cpoptimizer/create_model.py
@@ -4,7 +4,7 @@ from pyjobshop.ProblemData import ProblemData
 
 from .constraints import (
     job_spans_tasks,
-    no_overlap_and_setup_time_constraints,
+    no_overlap_and_setup_times,
     select_one_task_alternative,
     task_graph,
 )
@@ -56,7 +56,7 @@ def create_model(data: ProblemData) -> CpoModel:
 
     select_one_task_alternative(model, data, task_vars, assign_vars)
     job_spans_tasks(model, data, job_vars, task_vars)
-    no_overlap_and_setup_time_constraints(model, data, seq_vars)
+    no_overlap_and_setup_times(model, data, seq_vars)
     task_graph(model, data, task_vars, assign_vars, seq_vars)
 
     return model

--- a/pyjobshop/cpoptimizer/create_model.py
+++ b/pyjobshop/cpoptimizer/create_model.py
@@ -54,9 +54,9 @@ def create_model(data: ProblemData) -> CpoModel:
     else:
         raise ValueError(f"Unknown objective: {data.objective}")
 
-    select_one_task_alternative(model, data, task_vars, assign_vars)
     job_spans_tasks(model, data, job_vars, task_vars)
     no_overlap_and_setup_times(model, data, seq_vars)
+    select_one_task_alternative(model, data, task_vars, assign_vars)
     task_graph(model, data, task_vars, assign_vars, seq_vars)
 
     return model

--- a/pyjobshop/cpoptimizer/create_model.py
+++ b/pyjobshop/cpoptimizer/create_model.py
@@ -3,14 +3,10 @@ from docplex.cp.model import CpoModel
 from pyjobshop.ProblemData import ProblemData
 
 from .constraints import (
-    alternative_constraints,
-    job_data_constraints,
-    job_task_constraints,
+    job_spans_tasks,
     no_overlap_and_setup_time_constraints,
-    planning_horizon_constraints,
-    processing_time_constraints,
-    task_constraints,
-    task_graph_constraints,
+    select_one_task_alternative,
+    task_graph,
 )
 from .objectives import (
     makespan,
@@ -58,19 +54,9 @@ def create_model(data: ProblemData) -> CpoModel:
     else:
         raise ValueError(f"Unknown objective: {data.objective}")
 
-    model.add(job_data_constraints(model, data, job_vars))
-    model.add(job_task_constraints(model, data, job_vars, task_vars))
-    model.add(task_constraints(model, data, task_vars))
-    model.add(alternative_constraints(model, data, task_vars, assign_vars))
-    model.add(no_overlap_and_setup_time_constraints(model, data, seq_vars))
-    model.add(
-        planning_horizon_constraints(
-            model, data, job_vars, assign_vars, task_vars
-        )
-    )
-    model.add(processing_time_constraints(model, data, assign_vars))
-    model.add(
-        task_graph_constraints(model, data, task_vars, assign_vars, seq_vars)
-    )
+    select_one_task_alternative(model, data, task_vars, assign_vars)
+    job_spans_tasks(model, data, job_vars, task_vars)
+    no_overlap_and_setup_time_constraints(model, data, seq_vars)
+    task_graph(model, data, task_vars, assign_vars, seq_vars)
 
     return model

--- a/pyjobshop/cpoptimizer/objectives.py
+++ b/pyjobshop/cpoptimizer/objectives.py
@@ -1,62 +1,54 @@
-from docplex.cp.expression import CpoExpr, CpoIntervalVar
+from docplex.cp.expression import CpoIntervalVar
 from docplex.cp.model import CpoModel
 
 from pyjobshop.ProblemData import ProblemData
 
 
-def makespan(
-    m: CpoModel, data: ProblemData, op_vars: list[CpoIntervalVar]
-) -> CpoExpr:
+def makespan(m: CpoModel, data: ProblemData, op_vars: list[CpoIntervalVar]):
     """
     Minimizes the makespan of the schedule.
     """
-    return m.minimize(m.max(m.end_of(var) for var in op_vars))
+    m.add(m.minimize(m.max(m.end_of(var) for var in op_vars)))
 
 
-def tardy_jobs(
-    m: CpoModel, data: ProblemData, job_vars: list[CpoIntervalVar]
-) -> CpoExpr:
+def tardy_jobs(m: CpoModel, data: ProblemData, job_vars: list[CpoIntervalVar]):
     """
     Minimize the number of tardy jobs.
     """
     total = []
 
-    for job_data, job_var in zip(data.jobs, job_vars):
-        is_tardy = m.greater(m.end_of(job_var) - job_data.due_date, 0)
+    for job, var in zip(data.jobs, job_vars):
+        is_tardy = m.greater(m.end_of(var) - job.due_date, 0)
         total.append(is_tardy)
 
-    return m.minimize(m.sum(total))
+    m.add(m.minimize(m.sum(total)))
 
 
 def total_completion_time(
     m: CpoModel, data: ProblemData, job_vars: list[CpoIntervalVar]
-) -> CpoExpr:
+):
     """
-    Minimizes the sum of the completion times of each job.
+    Minimizes the weighted sum of the completion times of each job.
     """
     total = []
 
-    for job_data, job_var in zip(data.jobs, job_vars):
-        completion_time = job_data.weight * m.end_of(job_var)
+    for job, var in zip(data.jobs, job_vars):
+        completion_time = job.weight * m.end_of(var)
         total.append(completion_time)
 
-    return m.minimize(m.sum(total))
+    m.add(m.minimize(m.sum(total)))
 
 
 def total_tardiness(
     m: CpoModel, data: ProblemData, job_vars: list[CpoIntervalVar]
-) -> CpoExpr:
+):
     """
-    Minimizes the sum of the tardiness of each job. A job's tardiness is
-    defined as the maximum of 0 and its completion time minus the job's
-    due date.
+    Minimizes the weighted sum of the tardiness of each job.
     """
     total = []
 
-    for job_data, job_var in zip(data.jobs, job_vars):
-        tardiness = m.max(
-            0, job_data.weight * (m.end_of(job_var) - job_data.due_date)
-        )
+    for job, var in zip(data.jobs, job_vars):
+        tardiness = m.max(0, job.weight * (m.end_of(var) - job.due_date))
         total.append(tardiness)
 
-    return m.minimize(m.sum(total))
+    m.add(m.minimize(m.sum(total)))

--- a/pyjobshop/cpoptimizer/variables.py
+++ b/pyjobshop/cpoptimizer/variables.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from docplex.cp.expression import CpoIntervalVar, CpoSequenceVar
 from docplex.cp.model import CpoModel
 
@@ -10,14 +12,49 @@ def job_variables(m: CpoModel, data: ProblemData) -> list[CpoIntervalVar]:
     """
     Creates an interval variable for each job in the problem.
     """
-    return [m.interval_var(name=f"J{idx}") for idx in range(data.num_jobs)]
+    variables = []
+
+    for job in data.jobs:
+        var = m.interval_var(name=f"J{job}")
+
+        var.set_start_min(job.release_date)
+        var.set_end_max(min(job.deadline, data.planning_horizon))
+
+        variables.append(var)
+
+    return variables
 
 
 def task_variables(m: CpoModel, data: ProblemData) -> list[CpoIntervalVar]:
     """
     Creates an interval variable for each task in the problem.
     """
-    return [m.interval_var(name=f"O{idx}") for idx in range(data.num_tasks)]
+    variables = []
+
+    # Improve duration bounds using processing times.
+    min_durations: dict[int, int] = defaultdict(lambda: data.planning_horizon)
+    max_durations: dict[int, int] = defaultdict(lambda: 0)
+
+    for (_, task_idx), duration in data.processing_times.items():
+        min_durations[task_idx] = min(min_durations[task_idx], duration)
+        max_durations[task_idx] = max(max_durations[task_idx], duration)
+
+    for idx, task in enumerate(data.tasks):
+        var = m.interval_var(name=f"T{task}")
+
+        var.set_start_min(task.earliest_start)
+        var.set_start_max(task.latest_start)
+
+        var.set_end_min(task.earliest_end)
+        var.set_end_max(min(task.latest_end, data.planning_horizon))
+
+        var.set_size_min(min_durations[idx])
+        if task.fixed_duration:
+            var.set_size_max(max_durations[idx])
+
+        variables.append(var)
+
+    return variables
 
 
 def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
@@ -25,13 +62,28 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
     Creates an optional interval variable for each task and eligible
     machine pair, i.e., a task.
     """
-    return {
-        (task, machine): m.interval_var(
-            name=f"A{task}_{machine}", optional=True
-        )
-        for task in range(data.num_tasks)
-        for machine in data.task2machines[task]
-    }
+    variables = {}
+
+    for task_idx in range(data.num_tasks):
+        for machine in data.task2machines[task_idx]:
+            var = m.interval_var(optional=True, name=f"A{task_idx}_{machine}")
+            task = data.tasks[task_idx]
+
+            var.set_start_min(task.earliest_start)
+            var.set_start_max(task.latest_start)
+
+            var.set_end_min(task.earliest_end)
+            var.set_end_max(min(task.latest_end, data.planning_horizon))
+
+            duration = data.processing_times[machine, task_idx]
+            if task.fixed_duration:
+                var.set_size(duration)
+            else:
+                var.set_size_min(duration)  # at least duration
+
+            variables[task_idx, machine] = var
+
+    return variables
 
 
 def sequence_variables(

--- a/pyjobshop/cpoptimizer/variables.py
+++ b/pyjobshop/cpoptimizer/variables.py
@@ -1,9 +1,8 @@
-from collections import defaultdict
-
 from docplex.cp.expression import CpoIntervalVar, CpoSequenceVar
 from docplex.cp.model import CpoModel
 
 from pyjobshop.ProblemData import ProblemData
+from pyjobshop.utils import compute_min_max_durations
 
 AssignVars = dict[tuple[int, int], CpoIntervalVar]
 
@@ -30,14 +29,7 @@ def task_variables(m: CpoModel, data: ProblemData) -> list[CpoIntervalVar]:
     Creates an interval variable for each task in the problem.
     """
     variables = []
-
-    # Improve duration bounds using processing times.
-    min_durations: dict[int, int] = defaultdict(lambda: data.planning_horizon)
-    max_durations: dict[int, int] = defaultdict(lambda: 0)
-
-    for (_, task_idx), duration in data.processing_times.items():
-        min_durations[task_idx] = min(min_durations[task_idx], duration)
-        max_durations[task_idx] = max(max_durations[task_idx], duration)
+    min_durations, max_durations = compute_min_max_durations(data)
 
     for idx, task in enumerate(data.tasks):
         var = m.interval_var(name=f"T{task}")

--- a/pyjobshop/ortools/objectives.py
+++ b/pyjobshop/ortools/objectives.py
@@ -5,15 +5,15 @@ from pyjobshop.ProblemData import ProblemData
 from .variables import JobVar, TaskVar
 
 
-def makespan(model: CpModel, data: ProblemData, task_vars: list[TaskVar]):
+def makespan(m: CpModel, data: ProblemData, task_vars: list[TaskVar]):
     """
     Minimizes the makespan.
     """
-    makespan = model.new_int_var(0, data.planning_horizon, "makespan")
+    makespan = m.new_int_var(0, data.planning_horizon, "makespan")
     completion_times = [var.end for var in task_vars]
 
-    model.add_max_equality(makespan, completion_times)
-    model.minimize(makespan)
+    m.add_max_equality(makespan, completion_times)
+    m.minimize(makespan)
 
 
 def tardy_jobs(m: CpModel, data: ProblemData, job_vars: list[JobVar]):

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -1,9 +1,9 @@
-from collections import defaultdict
 from dataclasses import dataclass
 
 from ortools.sat.python.cp_model import BoolVarT, CpModel, IntervalVar, IntVar
 
 from pyjobshop.ProblemData import ProblemData
+from pyjobshop.utils import compute_min_max_durations
 
 
 @dataclass
@@ -154,14 +154,7 @@ def task_variables(m: CpModel, data: ProblemData) -> list[TaskVar]:
     Creates an interval variable for each task.
     """
     variables = []
-
-    # Improve duration bounds using processing times.
-    min_durations: dict[int, int] = defaultdict(lambda: data.planning_horizon)
-    max_durations: dict[int, int] = defaultdict(lambda: 0)
-
-    for (_, task_idx), duration in data.processing_times.items():
-        min_durations[task_idx] = min(min_durations[task_idx], duration)
-        max_durations[task_idx] = max(max_durations[task_idx], duration)
+    min_durations, max_durations = compute_min_max_durations(data)
 
     for idx, task in enumerate(data.tasks):
         name = f"T{task}"

--- a/pyjobshop/utils.py
+++ b/pyjobshop/utils.py
@@ -1,0 +1,34 @@
+from pyjobshop.ProblemData import ProblemData
+
+
+def compute_min_max_durations(
+    data: ProblemData,
+) -> tuple[list[int], list[int]]:
+    """
+    Compute the minimum and maximum durations for each task. This is used to
+    improve the duration bounds of the corresponding interval variables.
+
+    Parameters
+    ----------
+    data
+        The problem data instance.
+
+    Returns
+    -------
+    tuple[list[int], list[int]]
+        The minimum and maximum durations for each task.
+    """
+    durations: list[list[int]] = [[] for _ in range(data.num_tasks)]
+    for (_, task), duration in data.processing_times.items():
+        durations[task].append(duration)
+
+    min_durations, max_durations = [], []
+    for task in range(data.num_tasks):
+        if durations[task]:
+            min_durations.append(min(durations[task]))
+            max_durations.append(max(durations[task]))
+        else:  # TODO This is a strange case, see #135.
+            min_durations.append(0)
+            max_durations.append(data.planning_horizon)
+
+    return min_durations, max_durations

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -344,7 +344,7 @@ def test_job_deadline_infeasible(solver: str):
 
     result = model.solve(solver=solver)
 
-    # Task's processing time is 2, but job deadline is 1.
+    # The processing time of the task is 2, but job deadline is 1.
     assert_equal(result.status.value, "Infeasible")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+from numpy.testing import assert_equal
+
+from pyjobshop.ProblemData import Job, Machine, ProblemData, Task
+from pyjobshop.utils import compute_min_max_durations
+
+
+def test_compute_min_max_durations():
+    """
+    Tests that the minimum and maximum durations are correctly computed.
+    """
+    data = ProblemData(
+        [Job()],
+        [Machine(), Machine()],
+        [Task(), Task()],
+        [[0, 0]],
+        {(0, 0): 1, (1, 0): 10},
+        {},
+    )
+
+    min_durations, max_durations = compute_min_max_durations(data)
+
+    # First task has processing times 1 and 10, whereas the second task has
+    # no processing times, so we expect the default values.
+    assert_equal(min_durations, [1, 0])
+    assert_equal(max_durations, [10, data.planning_horizon])


### PR DESCRIPTION
This PR refactors the CP Optimizer implementation following the same adjustments as made in #130. Some differences:
- Instead of initializing variables with the bounds on start/end/duration, we use setters. I find this easier to read and maintain.