### PR TITLE
Rename planning horizon

### DIFF
--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -31,7 +31,7 @@ class Model:
         )
 
         self._setup_times: dict[tuple[int, int, int], int] = {}
-        self._planning_horizon: int = MAX_VALUE
+        self._horizon: int = MAX_VALUE
         self._objective: Objective = Objective.MAKESPAN
 
         self._id2job: dict[int, int] = {}
@@ -85,7 +85,7 @@ class Model:
             processing_times=self._processing_times,
             constraints=self._constraints,
             setup_times=setup_times,
-            planning_horizon=self._planning_horizon,
+            horizon=self._horizon,
             objective=self._objective,
         )
 
@@ -272,16 +272,16 @@ class Model:
 
         self._setup_times[machine_idx, task_idx1, task_idx2] = duration
 
-    def set_planning_horizon(self, horizon: int):
+    def set_horizon(self, horizon: int):
         """
-        Sets the planning horizon of the model.
+        Sets the horizon of the model.
 
         Parameters
         ----------
         horizon
-            The planning horizon.
+            The horizon.
         """
-        self._planning_horizon = horizon
+        self._horizon = horizon
 
     def set_objective(self, objective: Objective):
         """

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -409,7 +409,8 @@ class ProblemData:
     @property
     def horizon(self) -> int:
         """
-        The horizon of this instance.
+        The time horizon of this instance. This is an upper bound on the
+        completion time of all tasks.
 
         Returns
         -------

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -272,8 +272,8 @@ class ProblemData:
         Sequence-dependent setup times between tasks on a given machine.
         The first dimension of the array is indexed by the machine index. The
         last two dimensions of the array are indexed by task indices.
-    planning_horizon
-        The planning horizon value. Default ``MAX_VALUE``.
+    horizon
+        The horizon value. Default ``MAX_VALUE``.
     objective
         The objective function to be minimized. Default is the makespan.
     """
@@ -286,7 +286,7 @@ class ProblemData:
         processing_times: dict[tuple[int, int], int],
         constraints: _CONSTRAINTS_TYPE,
         setup_times: Optional[np.ndarray] = None,
-        planning_horizon: int = MAX_VALUE,
+        horizon: int = MAX_VALUE,
         objective: Objective = Objective.MAKESPAN,
     ):
         self._jobs = jobs
@@ -303,7 +303,7 @@ class ProblemData:
             if setup_times is not None
             else np.zeros((num_mach, num_tasks, num_tasks), dtype=int)
         )
-        self._planning_horizon = planning_horizon
+        self._horizon = horizon
         self._objective = objective
 
         self._machine2tasks: list[list[int]] = [[] for _ in range(num_mach)]
@@ -336,8 +336,8 @@ class ProblemData:
             msg = "Setup times shape not (num_machines, num_tasks, num_tasks)."
             raise ValueError(msg)
 
-        if self.planning_horizon < 0:
-            raise ValueError("Planning horizon must be non-negative.")
+        if self.horizon < 0:
+            raise ValueError("Horizon must be non-negative.")
 
         if self.objective in [Objective.TARDY_JOBS, Objective.TOTAL_TARDINESS]:
             if any(job.due_date is None for job in self.jobs):
@@ -407,16 +407,16 @@ class ProblemData:
         return self._setup_times
 
     @property
-    def planning_horizon(self) -> int:
+    def horizon(self) -> int:
         """
-        The planning horizon of this instance.
+        The horizon of this instance.
 
         Returns
         -------
         int
-            The planning horizon value.
+            The horizon value.
         """
-        return self._planning_horizon
+        return self._horizon
 
     @property
     def objective(self) -> Objective:

--- a/pyjobshop/cpoptimizer/variables.py
+++ b/pyjobshop/cpoptimizer/variables.py
@@ -35,14 +35,15 @@ def task_variables(m: CpoModel, data: ProblemData) -> list[CpoIntervalVar]:
         var = m.interval_var(name=f"T{task}")
 
         var.set_start_min(task.earliest_start)
-        var.set_start_max(task.latest_start)
+        var.set_start_max(min(task.latest_start, data.horizon))
 
         var.set_end_min(task.earliest_end)
         var.set_end_max(min(task.latest_end, data.horizon))
 
         var.set_size_min(min_durations[idx])
-        if task.fixed_duration:
-            var.set_size_max(max_durations[idx])
+        var.set_size_max(
+            max_durations[idx] if task.fixed_duration else data.horizon
+        )
 
         variables.append(var)
 
@@ -62,7 +63,7 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
             task = data.tasks[task_idx]
 
             var.set_start_min(task.earliest_start)
-            var.set_start_max(task.latest_start)
+            var.set_start_max(min(task.latest_start, data.horizon))
 
             var.set_end_min(task.earliest_end)
             var.set_end_max(min(task.latest_end, data.horizon))
@@ -71,7 +72,8 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
             if task.fixed_duration:
                 var.set_size(duration)
             else:
-                var.set_size_min(duration)  # at least duration
+                var.set_size_min(duration)
+                var.set_size_max(data.horizon)
 
             variables[task_idx, machine] = var
 

--- a/pyjobshop/cpoptimizer/variables.py
+++ b/pyjobshop/cpoptimizer/variables.py
@@ -17,7 +17,7 @@ def job_variables(m: CpoModel, data: ProblemData) -> list[CpoIntervalVar]:
         var = m.interval_var(name=f"J{job}")
 
         var.set_start_min(job.release_date)
-        var.set_end_max(min(job.deadline, data.planning_horizon))
+        var.set_end_max(min(job.deadline, data.horizon))
 
         variables.append(var)
 
@@ -38,7 +38,7 @@ def task_variables(m: CpoModel, data: ProblemData) -> list[CpoIntervalVar]:
         var.set_start_max(task.latest_start)
 
         var.set_end_min(task.earliest_end)
-        var.set_end_max(min(task.latest_end, data.planning_horizon))
+        var.set_end_max(min(task.latest_end, data.horizon))
 
         var.set_size_min(min_durations[idx])
         if task.fixed_duration:
@@ -65,7 +65,7 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
             var.set_start_max(task.latest_start)
 
             var.set_end_min(task.earliest_end)
-            var.set_end_max(min(task.latest_end, data.planning_horizon))
+            var.set_end_max(min(task.latest_end, data.horizon))
 
             duration = data.processing_times[machine, task_idx]
             if task.fixed_duration:

--- a/pyjobshop/ortools/objectives.py
+++ b/pyjobshop/ortools/objectives.py
@@ -9,7 +9,7 @@ def makespan(m: CpModel, data: ProblemData, task_vars: list[TaskVar]):
     """
     Minimizes the makespan.
     """
-    makespan = m.new_int_var(0, data.planning_horizon, "makespan")
+    makespan = m.new_int_var(0, data.horizon, "makespan")
     completion_times = [var.end for var in task_vars]
 
     m.add_max_equality(makespan, completion_times)
@@ -51,7 +51,7 @@ def total_tardiness(m: CpModel, data: ProblemData, job_vars: list[JobVar]):
     exprs = []
 
     for job, var in zip(data.jobs, job_vars):
-        tardiness = m.new_int_var(0, data.planning_horizon, f"tardiness_{job}")
+        tardiness = m.new_int_var(0, data.horizon, f"tardiness_{job}")
         exprs.append(tardiness)
 
         m.add_max_equality(tardiness, [0, var.end - job.due_date])

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -130,17 +130,17 @@ def job_variables(m: CpModel, data: ProblemData) -> list[JobVar]:
         name = f"J{job}"
         start = m.new_int_var(
             lb=job.release_date,
-            ub=data.planning_horizon,
+            ub=data.horizon,
             name=f"{name}_start",
         )
         duration = m.new_int_var(
             lb=0,
-            ub=min(job.deadline - job.release_date, data.planning_horizon),
+            ub=min(job.deadline - job.release_date, data.horizon),
             name=f"{name}_duration",
         )
         end = m.new_int_var(
             lb=0,
-            ub=min(job.deadline, data.planning_horizon),
+            ub=min(job.deadline, data.horizon),
             name=f"{name}_end",
         )
         interval = m.NewIntervalVar(start, duration, end, f"{name}_interval")
@@ -160,19 +160,19 @@ def task_variables(m: CpModel, data: ProblemData) -> list[TaskVar]:
         name = f"T{task}"
         start = m.new_int_var(
             lb=task.earliest_start,
-            ub=min(task.latest_start, data.planning_horizon),
+            ub=min(task.latest_start, data.horizon),
             name=f"{name}_start",
         )
         duration = m.new_int_var(
             lb=min_durations[idx],
             ub=max_durations[idx]
             if task.fixed_duration
-            else data.planning_horizon,  # unbounded if variable duration
+            else data.horizon,  # unbounded if variable duration
             name=f"{name}_duration",
         )
         end = m.new_int_var(
             lb=task.earliest_end,
-            ub=min(task.latest_end, data.planning_horizon),
+            ub=min(task.latest_end, data.horizon),
             name=f"{name}_end",
         )
         interval = m.NewIntervalVar(start, duration, end, f"interval_{task}")
@@ -195,17 +195,17 @@ def assignment_variables(
         name = f"A{task}_{machine}"
         start = m.new_int_var(
             lb=task.earliest_start,
-            ub=min(task.latest_start, data.planning_horizon),
+            ub=min(task.latest_start, data.horizon),
             name=f"{name}_start",
         )
         duration = m.new_int_var(
             lb=proc_time,
-            ub=proc_time if task.fixed_duration else data.planning_horizon,
+            ub=proc_time if task.fixed_duration else data.horizon,
             name=f"{name}_duration",
         )
         end = m.new_int_var(
             lb=task.earliest_end,
-            ub=min(task.latest_end, data.planning_horizon),
+            ub=min(task.latest_end, data.horizon),
             name=f"{name}_start",
         )
         is_present = m.new_bool_var(f"{name}_is_present")

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -165,9 +165,7 @@ def task_variables(m: CpModel, data: ProblemData) -> list[TaskVar]:
         )
         duration = m.new_int_var(
             lb=min_durations[idx],
-            ub=max_durations[idx]
-            if task.fixed_duration
-            else data.horizon,  # unbounded if variable duration
+            ub=max_durations[idx] if task.fixed_duration else data.horizon,
             name=f"{name}_duration",
         )
         end = m.new_int_var(

--- a/pyjobshop/utils.py
+++ b/pyjobshop/utils.py
@@ -29,6 +29,6 @@ def compute_min_max_durations(
             max_durations.append(max(durations[task]))
         else:  # TODO This is a strange case, see #135.
             min_durations.append(0)
-            max_durations.append(data.planning_horizon)
+            max_durations.append(data.horizon)
 
     return min_durations, max_durations

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -29,7 +29,7 @@ def test_model_to_data():
     model.add_setup_time(mach1, task1, task2, 3)
     model.add_setup_time(mach2, task1, task2, 4)
 
-    model.set_planning_horizon(100)
+    model.set_horizon(100)
     model.set_objective(Objective.TOTAL_COMPLETION_TIME)
 
     data = model.data()
@@ -52,7 +52,7 @@ def test_model_to_data():
         },
     )
     assert_equal(data.setup_times, [[[0, 3], [0, 0]], [[0, 4], [0, 0]]])
-    assert_equal(data.planning_horizon, 100)
+    assert_equal(data.horizon, 100)
     assert_equal(data.objective, Objective.TOTAL_COMPLETION_TIME)
 
 
@@ -74,7 +74,7 @@ def test_model_to_data_default_values():
     assert_equal(data.processing_times, {})
     assert_equal(data.constraints, {})
     assert_equal(data.setup_times, [[[0]]])
-    assert_equal(data.planning_horizon, MAX_VALUE)
+    assert_equal(data.horizon, MAX_VALUE)
     assert_equal(data.objective, Objective.MAKESPAN)
 
 

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -165,7 +165,7 @@ def test_problem_data_input_parameter_attributes():
         key: [Constraint.END_BEFORE_START] for key in ((0, 1), (2, 3), (4, 5))
     }
     setup_times = np.ones((5, 5, 5), dtype=int)
-    planning_horizon = 100
+    horizon = 100
     objective = Objective.TOTAL_COMPLETION_TIME
 
     data = ProblemData(
@@ -175,7 +175,7 @@ def test_problem_data_input_parameter_attributes():
         processing_times,
         constraints,
         setup_times,
-        planning_horizon,
+        horizon,
         objective,
     )
 
@@ -185,7 +185,7 @@ def test_problem_data_input_parameter_attributes():
     assert_equal(data.processing_times, processing_times)
     assert_equal(data.constraints, constraints)
     assert_allclose(data.setup_times, setup_times)
-    assert_equal(data.planning_horizon, planning_horizon)
+    assert_equal(data.horizon, horizon)
     assert_equal(data.objective, objective)
 
 
@@ -224,7 +224,7 @@ def test_problem_data_default_values():
     data = ProblemData(jobs, machines, tasks, processing_times, constraints)
 
     assert_allclose(data.setup_times, np.zeros((1, 1, 1), dtype=int))
-    assert_equal(data.planning_horizon, MAX_VALUE)
+    assert_equal(data.horizon, MAX_VALUE)
     assert_equal(data.objective, Objective.MAKESPAN)
 
 
@@ -243,7 +243,7 @@ def test_problem_data_job_references_invalid_task():
 
 
 @pytest.mark.parametrize(
-    "processing_times, setup_times, planning_horizon",
+    "processing_times, setup_times, horizon",
     [
         # Negative processing times.
         ({(0, 0): -1}, np.ones((1, 1, 1)), 1),
@@ -251,14 +251,14 @@ def test_problem_data_job_references_invalid_task():
         ({(0, 0): 1}, np.ones((1, 1, 1)) * -1, 1),
         # Invalid setup times shape.
         ({(0, 0): 1}, np.ones((2, 2, 2)), 1),
-        # Negative planning horizon.
+        # Negative horizon.
         ({(0, 0): 1}, np.ones((2, 2, 2)), -1),
     ],
 )
 def test_problem_data_raises_when_invalid_arguments(
     processing_times: dict[tuple[int, int], int],
     setup_times: np.ndarray,
-    planning_horizon: int,
+    horizon: int,
 ):
     """
     Tests that the ProblemData class raises an error when invalid arguments are
@@ -272,7 +272,7 @@ def test_problem_data_raises_when_invalid_arguments(
             processing_times,
             {},
             setup_times.astype(int),
-            planning_horizon=planning_horizon,
+            horizon=horizon,
         )
 
 
@@ -681,9 +681,9 @@ def test_assignment_constraint(
     assert_equal(result.objective, expected_makespan)
 
 
-def test_tight_planning_horizon_results_in_infeasiblity(solver: str):
+def test_tight_horizon_results_in_infeasiblity(solver: str):
     """
-    Tests that a tight planning horizon results in an infeasible instance.
+    Tests that a tight horizon results in an infeasible instance.
     """
     model = Model()
 
@@ -692,11 +692,11 @@ def test_tight_planning_horizon_results_in_infeasiblity(solver: str):
     task = model.add_task(job=job)
 
     model.add_processing_time(machine, task, duration=2)
-    model.set_planning_horizon(1)
+    model.set_horizon(1)
 
     result = model.solve(solver=solver)
 
-    # Processing time is 2, but planning horizon is 1, so this is infeasible.
+    # Processing time is 2, but horizon is 1, so this is infeasible.
     assert_equal(result.status.value, "Infeasible")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,4 +21,4 @@ def test_compute_min_max_durations():
     # First task has processing times 1 and 10, whereas the second task has
     # no processing times, so we expect the default values.
     assert_equal(min_durations, [1, 0])
-    assert_equal(max_durations, [10, data.planning_horizon])
+    assert_equal(max_durations, [10, data.horizon])


### PR DESCRIPTION
This PR renames `planning_horizon` to the less verbose `horizon`