### PR TITLE
[OR-Tools] Lazy generate arc sequence variables

### DIFF
--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -77,7 +77,7 @@ def activate_setup_times(
         setup_times = data.setup_times[machine]
 
         if np.any(setup_times != 0):
-            seq_vars[machine].activate()
+            seq_vars[machine].activate(m)
 
 
 def task_graph(
@@ -129,7 +129,7 @@ def task_graph(
 
             for constraint in data.constraints[task1, task2]:
                 if constraint == "previous":
-                    sequence.activate()
+                    sequence.activate(m)
 
                     idx1 = sequence.tasks.index(var1)
                     idx2 = sequence.tasks.index(var2)
@@ -140,7 +140,7 @@ def task_graph(
                     m.add_implication(arc, var1.is_present)
                     m.add_implication(arc, var2.is_present)
                 if constraint == "before":
-                    sequence.activate()
+                    sequence.activate(m)
                     both_present = m.new_bool_var("")
 
                     # both_present <=> var1.is_present & var2.is_present

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -99,6 +99,9 @@ class SequenceVar:
     ranks
         The rank variables of each interval on the machine. Used to define the
         ordering of the intervals in the machine sequence.
+    arcs
+        The arc literals between each pair of intervals in the sequence.
+        Keys are tuples of indices.
     is_active
         A boolean that indicates whether the sequence is active, meaning that a
         circuit constraint must be added for this machine. Default ``False``.

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -119,7 +119,7 @@ class SequenceVar:
         Activates the sequence variable by creating all relevant literals.
         """
         if self.is_active:
-            return  # already activated
+            return
 
         self.is_active = True
         num_tasks = len(self.tasks)


### PR DESCRIPTION
Part of #123. I came across this issue when implementing #136, where large FJSP instances take forever to create.