### PR TITLE
Allow newer Python versions and bump CPLEX

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
         id: cache-python
         with:
           path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
       - name: Install Python dependencies
         if: steps.cache-python.outputs.cache-hit != 'true'
         run: poetry install --all-extras
@@ -37,7 +37,7 @@ jobs:
         id: cache-pre-commit
         with:
           path: ~/.cache/pre-commit/
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit-${{ env.pythonLocation }}-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install pre-commit
         if: steps.cache-pre-commit.outputs.cache-hit != 'true'
         run: poetry run pre-commit install --install-hooks

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
       - name: Update pip and poetry
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,9 +8,12 @@ on:
 
 jobs:
   build:
+    name: Test pyjobshop using Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
+      matrix:
+        python-version: ['3.9', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ enum-tools = "^0.11.0"
 progiter = "^2.0.0"
 tomli = "^2.0.1"
 fjsplib = { git = "https://github.com/PyJobShop/FJSPLIB.git", rev = "75b2d18" }
+cplex = { version = "22.1.1.2", optional = true, markers = "python_version < '3.12'"}
 docplex = { version = "^2.25.236", optional = true }
-cplex = { version = "22.1.1.0", optional = true }
 
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ enum-tools = "^0.11.0"
 progiter = "^2.0.0"
 tomli = "^2.0.1"
 fjsplib = { git = "https://github.com/PyJobShop/FJSPLIB.git", rev = "75b2d18" }
-cplex = { version = "22.1.1.2", optional = true, markers = "python_version < '3.12'"}
+cplex = { version = "22.1.1.2", optional = true }
 docplex = { version = "^2.25.236", optional = true }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "poetry.core.masonry.api"
 
 
 [tool.poetry.dependencies]
-python = ">=3.9, <3.11"
+python = ">=3.9, <4.0"
 numpy = "^1.24.2"
 matplotlib = "^3.7.1"
 ortools = "^9.10.4067"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ enum-tools = "^0.11.0"
 progiter = "^2.0.0"
 tomli = "^2.0.1"
 fjsplib = { git = "https://github.com/PyJobShop/FJSPLIB.git", rev = "75b2d18" }
-cplex = { version = "22.1.1.2", optional = true }
+cplex = { version = "22.1.1.2", optional = true, markers = "python_version < '3.12'"}
 docplex = { version = "^2.25.236", optional = true }
 
 


### PR DESCRIPTION
This PR:
- Allows higher versions of Python.
	- Historical note: CPLEX 21.1.0 came only with Python 3.9 and Python 3.10, so I restricted the Python versions at the time.
- Bumps CPLEX to 21.1.1.2, which supports Python 3.11.