### PR TITLE
[OR-Tools] Remove variable helper classes

### DIFF
--- a/pyjobshop/ortools/constraints.py
+++ b/pyjobshop/ortools/constraints.py
@@ -1,20 +1,22 @@
 from itertools import product
 
 import numpy as np
-from ortools.sat.python.cp_model import CpModel
+from ortools.sat.python.cp_model import CpModel, IntervalVar
 
 from pyjobshop.ProblemData import ProblemData
 
-from .variables import JobVar, SequenceVar, TaskAltVar, TaskVar
+from .variables import SequenceVar, TaskAltVar, TaskVar
 
-JobVars = list[JobVar]
 TaskVars = list[TaskVar]
 TaskAltVars = dict[tuple[int, int], TaskAltVar]
 SequenceVars = list[SequenceVar]
 
 
 def job_spans_tasks(
-    m: CpModel, data: ProblemData, job_vars: JobVars, task_vars: TaskVars
+    m: CpModel,
+    data: ProblemData,
+    job_vars: list[IntervalVar],
+    task_vars: TaskVars,
 ):
     """
     Ensures that the job variables span the related task variables.
@@ -24,8 +26,8 @@ def job_spans_tasks(
         task_start_vars = [task_vars[task_idx].start for task_idx in job.tasks]
         task_end_vars = [task_vars[task_idx].end for task_idx in job.tasks]
 
-        m.add_min_equality(job_var.start, task_start_vars)
-        m.add_max_equality(job_var.end, task_end_vars)
+        m.add_min_equality(job_var.start_expr(), task_start_vars)
+        m.add_max_equality(job_var.end_expr(), task_end_vars)
 
 
 def select_one_task_alternative(

--- a/pyjobshop/ortools/objectives.py
+++ b/pyjobshop/ortools/objectives.py
@@ -2,15 +2,13 @@ from ortools.sat.python.cp_model import CpModel, IntervalVar, LinearExpr
 
 from pyjobshop.ProblemData import ProblemData
 
-from .variables import TaskVar
 
-
-def makespan(m: CpModel, data: ProblemData, task_vars: list[TaskVar]):
+def makespan(m: CpModel, data: ProblemData, task_vars: list[IntervalVar]):
     """
     Minimizes the makespan.
     """
     makespan = m.new_int_var(0, data.horizon, "makespan")
-    completion_times = [var.end for var in task_vars]
+    completion_times = [var.end_expr() for var in task_vars]
 
     m.add_max_equality(makespan, completion_times)
     m.minimize(makespan)

--- a/pyjobshop/ortools/variables.py
+++ b/pyjobshop/ortools/variables.py
@@ -8,29 +8,6 @@ from pyjobshop.utils import compute_min_max_durations
 
 
 @dataclass
-class TaskVar:
-    """
-    Variables that represent a task in the problem.
-
-    Parameters
-    ----------
-    interval
-        The interval variable representing the task.
-    start
-        The start time variable of the interval.
-    duration
-        The duration variable of the interval.
-    end
-        The end time variable of the interval.
-    """
-
-    interval: IntervalVar
-    start: IntVar
-    duration: IntVar
-    end: IntVar
-
-
-@dataclass
 class TaskAltVar:
     """
     Variables that represent an assignment of a task to a machine.
@@ -149,7 +126,7 @@ def job_variables(m: CpModel, data: ProblemData) -> list[IntervalVar]:
     return variables
 
 
-def task_variables(m: CpModel, data: ProblemData) -> list[TaskVar]:
+def task_variables(m: CpModel, data: ProblemData) -> list[IntervalVar]:
     """
     Creates an interval variable for each task.
     """
@@ -174,7 +151,7 @@ def task_variables(m: CpModel, data: ProblemData) -> list[TaskVar]:
             name=f"{name}_end",
         )
         interval = m.new_interval_var(start, duration, end, f"interval_{task}")
-        variables.append(TaskVar(interval, start, duration, end))
+        variables.append(interval)
 
     return variables
 
@@ -255,7 +232,7 @@ def add_hint_to_vars(
     data: ProblemData,
     solution: Solution,
     job_vars: list[IntervalVar],
-    task_vars: list[TaskVar],
+    task_vars: list[IntervalVar],
     task_alt_vars: dict[tuple[int, int], TaskAltVar],
 ):
     """
@@ -277,9 +254,9 @@ def add_hint_to_vars(
         task_var = task_vars[idx]
         sol_task = solution.tasks[idx]
 
-        m.add_hint(task_var.start, sol_task.start)
-        m.add_hint(task_var.duration, sol_task.duration)
-        m.add_hint(task_var.end, sol_task.end)
+        m.add_hint(task_var.start_expr(), sol_task.start)
+        m.add_hint(task_var.size_expr(), sol_task.duration)
+        m.add_hint(task_var.end_expr(), sol_task.end)
 
     for (task_idx, machine_idx), var in task_alt_vars.items():
         sol_task = solution.tasks[task_idx]


### PR DESCRIPTION
I found out that `IntervalVar` has methods for getting the respective start, size and end variables, so the helper classes are redundant.

TODO
- [ ] What to do with TaskAltVar?
	- There is no present literal accessor
- [ ] What to do with SequenceVar?
	- There is no such construct as in CP Optimizer