### PR TITLE
Separate instance reading and allow parallel solving instances

### DIFF
--- a/pyjobshop/__init__.py
+++ b/pyjobshop/__init__.py
@@ -7,4 +7,5 @@ from .ProblemData import Machine as Machine
 from .ProblemData import Objective as Objective
 from .ProblemData import ProblemData as ProblemData
 from .ProblemData import Task as Task
+from .read import read as read
 from .solve import solve as solve

--- a/pyjobshop/cli.py
+++ b/pyjobshop/cli.py
@@ -1,14 +1,15 @@
 import argparse
+import warnings
+from functools import partial
+from multiprocessing import cpu_count
 from pathlib import Path
 from typing import Optional
 
-import fjsplib
 import numpy as np
 import tomli
-from progiter import ProgIter
+from tqdm.contrib.concurrent import process_map
 
-import pyjobshop
-from pyjobshop import Model, solve
+from pyjobshop import read, solve
 
 
 def parse_args():
@@ -34,8 +35,16 @@ def parse_args():
     msg = "Whether to log the solver output."
     parser.add_argument("--log", action="store_true", help=msg)
 
-    msg = "Number of workers to use for parallel solving."
-    parser.add_argument("--num_workers", type=int, help=msg)
+    msg = (
+        "Number of worker threads to use for solving a single instance."
+        "Default is the number of available CPU cores."
+    )
+    parser.add_argument("--num_workers_per_instance", type=int, help=msg)
+
+    msg = "Number of instances to solve in parallel. Default is 1."
+    parser.add_argument(
+        "--num_parallel_instances", type=int, default=1, help=msg
+    )
 
     msg = """
     Optional parameter configuration file (in TOML format). These parameters
@@ -69,34 +78,12 @@ def tabulate(headers: list[str], rows: np.ndarray) -> str:
     return "\n".join(header + content)
 
 
-def instance2data(instance: fjsplib.Instance) -> pyjobshop.ProblemData:
-    """
-    Converts an FJSPLIB instance to a ProblemData object.
-    """
-    m = Model()
-
-    jobs = [m.add_job() for _ in range(instance.num_jobs)]
-    machines = [m.add_machine() for _ in range(instance.num_machines)]
-
-    for job_idx, tasks in enumerate(instance.jobs):
-        for task_data in tasks:
-            task = m.add_task(job=jobs[job_idx])
-
-            for machine_idx, duration in task_data:
-                m.add_processing_time(task, machines[machine_idx], duration)
-
-    for frm, to in instance.precedences:
-        m.add_end_before_start(m.tasks[frm], m.tasks[to])
-
-    return m.data()
-
-
 def _solve(
     instance_loc: Path,
     solver: str,
     time_limit: float,
     log: bool,
-    num_workers: int,
+    num_workers_per_instance: int,
     config_loc: Optional[Path],
 ) -> tuple[str, str, float, float]:
     """
@@ -108,9 +95,10 @@ def _solve(
     else:
         params = {}
 
-    instance = fjsplib.read(instance_loc)
-    data = instance2data(instance)
-    result = solve(data, solver, time_limit, log, num_workers, **params)
+    data = read(instance_loc)
+    result = solve(
+        data, solver, time_limit, log, num_workers_per_instance, **params
+    )
 
     return (
         instance_loc.name,
@@ -120,11 +108,47 @@ def _solve(
     )
 
 
-def benchmark(instances: list[Path], **kwargs):
+def _check_cpu_usage(
+    num_parallel_instances: int, num_workers_per_instance: Optional[int]
+):
+    """
+    Warns if the number of workers per instance times the number of parallel
+    instances is greater than the number of available CPU cores
+    """
+    num_cpus = cpu_count()
+    num_workers_per_instance = (
+        num_workers_per_instance
+        if num_workers_per_instance is not None
+        else num_cpus  # uses all CPUs if not set
+    )
+
+    if num_workers_per_instance * num_parallel_instances > num_cpus:
+        warnings.warn(
+            f"Number of workers per instance ({num_workers_per_instance}) "
+            f"times number of parallel instances ({num_parallel_instances}) "
+            f"is greater than the number of available CPU cores ({num_cpus}). "
+            "This may lead to suboptimal performance.",
+            stacklevel=2,
+        )
+
+
+def benchmark(instances: list[Path], num_parallel_instances: int, **kwargs):
     """
     Solves the list of instances and prints a table of the results.
     """
-    results = [_solve(instance, **kwargs) for instance in ProgIter(instances)]
+    _check_cpu_usage(
+        num_parallel_instances, kwargs.get("num_workers_per_instance")
+    )
+
+    args = sorted(instances)
+    func = partial(_solve, **kwargs)
+
+    if len(instances) == 1:
+        results = [func(args[0])]
+    else:
+        results = process_map(
+            func, args, max_workers=num_parallel_instances, unit="instance"
+        )
 
     dtypes = [
         ("inst", "U37"),

--- a/pyjobshop/read.py
+++ b/pyjobshop/read.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import fjsplib
+
+from .Model import Model
+from .ProblemData import ProblemData
+
+
+def read(loc: Path) -> ProblemData:
+    """
+    Reads an FJSPLIB instance and returns a ProblemData object.
+    """
+    instance = fjsplib.read(loc)
+
+    m = Model()
+
+    jobs = [m.add_job() for _ in range(instance.num_jobs)]
+    machines = [m.add_machine() for _ in range(instance.num_machines)]
+
+    for job_idx, tasks in enumerate(instance.jobs):
+        for task_data in tasks:
+            task = m.add_task(job=jobs[job_idx])
+
+            for machine_idx, duration in task_data:
+                m.add_processing_time(task, machines[machine_idx], duration)
+
+    for frm, to in instance.precedences:
+        m.add_end_before_start(m.tasks[frm], m.tasks[to])
+
+    return m.data()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ numpy = "^1.24.2"
 matplotlib = "^3.7.1"
 ortools = "^9.10.4067"
 enum-tools = "^0.11.0"
-progiter = "^2.0.0"
+tqdm = "^4.66.4"
 tomli = "^2.0.1"
 fjsplib = { git = "https://github.com/PyJobShop/FJSPLIB.git", rev = "75b2d18" }
 cplex = { version = "22.1.1.2", optional = true, markers = "python_version < '3.12'"}


### PR DESCRIPTION
This PR separates instance reading from CLI (so users can use `read.py` to read FJSPLIB) and allows parallel solving of instances. This is helpful when using the cluster to solve multiple instances in parallel.
