### PR TITLE
Replace processing times and task alternatives for modes

### DIFF
--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -27,7 +27,7 @@ class Model:
         self._jobs: list[Job] = []
         self._machines: list[Machine] = []
         self._tasks: list[Task] = []
-        self._modes = []
+        self._modes: list[Mode] = []
         self._constraints: dict[tuple[int, int], list[Constraint]] = (
             defaultdict(list)
         )

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -8,6 +8,7 @@ from pyjobshop.ProblemData import (
     Constraint,
     Job,
     Machine,
+    Mode,
     Objective,
     ProblemData,
     Task,
@@ -26,7 +27,7 @@ class Model:
         self._jobs: list[Job] = []
         self._machines: list[Machine] = []
         self._tasks: list[Task] = []
-        self._processing_times: dict[tuple[int, int], int] = {}
+        self._modes = []
         self._constraints: dict[tuple[int, int], list[Constraint]] = (
             defaultdict(list)
         )
@@ -102,7 +103,12 @@ class Model:
                 name=task.name,
             )
 
-        for (task_idx, mach_idx), duration in data.processing_times.items():
+        for mode in data.modes:
+            task_idx, mach_idx, duration = (
+                mode.task,
+                mode.resources[0],
+                mode.duration,
+            )
             model.add_processing_time(
                 task=model.tasks[task_idx],
                 machine=model.machines[mach_idx],
@@ -173,7 +179,7 @@ class Model:
             jobs=self.jobs,
             machines=self.machines,
             tasks=self.tasks,
-            processing_times=self._processing_times,
+            modes=self._modes,
             constraints=self._constraints,
             setup_times=setup_times,
             horizon=self._horizon,
@@ -313,7 +319,9 @@ class Model:
 
         task_idx = self._id2task[id(task)]
         machine_idx = self._id2machine[id(machine)]
-        self._processing_times[task_idx, machine_idx] = duration
+
+        mode = Mode(task_idx, duration, [machine_idx])
+        self._modes.append(mode)
 
     def add_start_at_start(self, first: Task, second: Task):
         """

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -104,15 +104,10 @@ class Model:
             )
 
         for mode in data.modes:
-            task_idx, mach_idx, duration = (
-                mode.task,
-                mode.resources[0],
-                mode.duration,
-            )
             model.add_processing_time(
-                task=model.tasks[task_idx],
-                machine=model.machines[mach_idx],
-                duration=duration,
+                task=model.tasks[mode.task],
+                machine=model.machines[mode.machine],
+                duration=mode.duration,
             )
 
         for (idx1, idx2), constraints in data.constraints.items():
@@ -320,8 +315,7 @@ class Model:
         task_idx = self._id2task[id(task)]
         machine_idx = self._id2machine[id(machine)]
 
-        mode = Mode(task_idx, duration, [machine_idx])
-        self._modes.append(mode)
+        self._modes.append(Mode(task_idx, duration, [machine_idx]))
 
     def add_start_at_start(self, first: Task, second: Task):
         """

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -410,6 +410,10 @@ class ProblemData:
             bisect.insort(self._machine2tasks[mode.machine], mode.task)
             bisect.insort(self._task2machines[mode.task], mode.machine)
 
+        self._machine2modes: list[list[int]] = [[] for _ in range(num_mach)]
+        for idx, mode in enumerate(self._modes):
+            bisect.insort(self._machine2modes[mode.machine], idx)
+
         self._validate_parameters()
 
     def _validate_parameters(self):
@@ -428,7 +432,7 @@ class ProblemData:
 
         tasks_with_processing = {mode.task for mode in self.modes}
         if set(range(num_tasks)) != tasks_with_processing:
-            raise ValueError("Processing times missing for some tasks.")
+            raise ValueError("Processing modes missing for some tasks.")
 
         if np.any(self.setup_times < 0):
             raise ValueError("Setup times must be non-negative.")

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -1,4 +1,3 @@
-import bisect
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
@@ -402,18 +401,6 @@ class ProblemData:
             objective if objective is not None else Objective.makespan()
         )
 
-        self._machine2tasks: list[list[int]] = [[] for _ in range(num_mach)]
-        self._task2machines: list[list[int]] = [[] for _ in range(num_tasks)]
-        self._task2modes: list[list[int]] = [[] for _ in range(num_tasks)]
-        for idx, mode in enumerate(self._modes):
-            self._task2modes[mode.task].append(idx)
-            bisect.insort(self._machine2tasks[mode.machine], mode.task)
-            bisect.insort(self._task2machines[mode.task], mode.machine)
-
-        self._machine2modes: list[list[int]] = [[] for _ in range(num_mach)]
-        for idx, mode in enumerate(self._modes):
-            bisect.insort(self._machine2modes[mode.machine], idx)
-
         self._validate_parameters()
 
     def _validate_parameters(self):
@@ -574,22 +561,6 @@ class ProblemData:
         The objective function.
         """
         return self._objective
-
-    @property
-    def machine2tasks(self) -> list[list[int]]:
-        """
-        List of task indices for each machine. These are inferred from
-        the (machine, task) pairs in the processing times dict.
-        """
-        return self._machine2tasks
-
-    @property
-    def task2machines(self) -> list[list[int]]:
-        """
-        List of eligible machine indices for each task. These are inferred
-        from the (machine, task) pairs in the processing times dict.
-        """
-        return self._task2machines
 
     @property
     def num_jobs(self) -> int:

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -331,6 +331,17 @@ class Objective:
 class Mode:
     """
     Simple dataclass for storing processing mode data.
+
+    Parameters
+    ----------
+    task
+        Task index that this mode belongs to.
+    duration
+        Processing duration of this mode.
+    resources
+        List of resources that are required for this mode.
+    demands
+        List of resource demands for this mode.
     """
 
     task: int

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -1,6 +1,6 @@
 import bisect
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, TypeVar
 
@@ -328,6 +328,22 @@ class Objective:
         return cls(weight_total_tardiness=1)
 
 
+@dataclass
+class Mode:
+    """
+    Simple dataclass for storing processing mode data.
+    """
+
+    task: int
+    duration: int
+    resources: list[int]
+    demands: list[int] = field(default_factory=list)
+
+    @property
+    def machine(self):
+        return self.resources[0]
+
+
 class ProblemData:
     """
     Creates a problem data instance. This instance contains all information
@@ -341,9 +357,8 @@ class ProblemData:
         List of machines.
     tasks
         List of tasks.
-    processing_times
-        Processing times of tasks on machines. First index is the task index,
-        second index is the machine index.
+    modes
+        List of processing modes of tasks.
     constraints
         Dict indexed by task pairs with a list of constraints as values.
         Default is None, which initializes an empty dict.
@@ -362,7 +377,7 @@ class ProblemData:
         jobs: list[Job],
         machines: list[Machine],
         tasks: list[Task],
-        processing_times: dict[tuple[int, int], int],
+        modes: list[Mode],
         constraints: Optional[_CONSTRAINTS_TYPE] = None,
         setup_times: Optional[np.ndarray] = None,
         horizon: int = MAX_VALUE,
@@ -371,7 +386,7 @@ class ProblemData:
         self._jobs = jobs
         self._machines = machines
         self._tasks = tasks
-        self._processing_times = processing_times
+        self._modes = modes
         self._constraints = constraints if constraints is not None else {}
 
         num_mach = self.num_machines
@@ -389,10 +404,11 @@ class ProblemData:
 
         self._machine2tasks: list[list[int]] = [[] for _ in range(num_mach)]
         self._task2machines: list[list[int]] = [[] for _ in range(num_tasks)]
-
-        for task, machine in self.processing_times.keys():
-            bisect.insort(self._machine2tasks[machine], task)
-            bisect.insort(self._task2machines[task], machine)
+        self._task2modes: list[list[int]] = [[] for _ in range(num_tasks)]
+        for idx, mode in enumerate(self._modes):
+            self._task2modes[mode.task].append(idx)
+            bisect.insort(self._machine2tasks[mode.machine], mode.task)
+            bisect.insort(self._task2machines[mode.task], mode.machine)
 
         self._validate_parameters()
 
@@ -407,10 +423,10 @@ class ProblemData:
             if any(task >= num_tasks for task in job.tasks):
                 raise ValueError("Job references to unknown task.")
 
-        if any(duration < 0 for duration in self.processing_times.values()):
-            raise ValueError("Processing times must be non-negative.")
+        if any(mode.duration < 0 for mode in self.modes):
+            raise ValueError("Processing mode duration must be non-negative.")
 
-        tasks_with_processing = {t for t, _ in self.processing_times.keys()}
+        tasks_with_processing = {mode.task for mode in self.modes}
         if set(range(num_tasks)) != tasks_with_processing:
             raise ValueError("Processing times missing for some tasks.")
 
@@ -437,7 +453,7 @@ class ProblemData:
         jobs: Optional[list[Job]] = None,
         machines: Optional[list[Machine]] = None,
         tasks: Optional[list[Task]] = None,
-        processing_times: Optional[dict[tuple[int, int], int]] = None,
+        modes: Optional[list[Mode]] = None,
         constraints: Optional[_CONSTRAINTS_TYPE] = None,
         setup_times: Optional[np.ndarray] = None,
         horizon: Optional[int] = None,
@@ -455,8 +471,8 @@ class ProblemData:
             Optional list of machines.
         tasks
             Optional list of tasks.
-        processing_times
-            Optional processing times of tasks on machines.
+        modes
+            Optional processing modes of tasks.
         constraints
             Optional constraints between tasks.
         setup_times
@@ -478,7 +494,7 @@ class ProblemData:
         jobs = _deepcopy_if_none(jobs, self.jobs)
         machines = _deepcopy_if_none(machines, self.machines)
         tasks = _deepcopy_if_none(tasks, self.tasks)
-        proc_times = _deepcopy_if_none(processing_times, self.processing_times)
+        modes = _deepcopy_if_none(modes, self.modes)
         constraints = _deepcopy_if_none(constraints, self.constraints)
         setup_times = _deepcopy_if_none(setup_times, self.setup_times)
         horizon = _deepcopy_if_none(horizon, self.horizon)
@@ -488,7 +504,7 @@ class ProblemData:
             jobs=jobs,
             machines=machines,
             tasks=tasks,
-            processing_times=proc_times,
+            modes=modes,
             constraints=constraints,
             setup_times=setup_times,
             horizon=horizon,
@@ -517,12 +533,11 @@ class ProblemData:
         return self._tasks
 
     @property
-    def processing_times(self) -> dict[tuple[int, int], int]:
+    def modes(self) -> list[Mode]:
         """
-        Processing times of tasks on machines. First index is the
-        task index, second index is the machine index.
+        Returns the processing modes of this problem instance.
         """
-        return self._processing_times
+        return self._modes
 
     @property
     def constraints(self) -> _CONSTRAINTS_TYPE:

--- a/pyjobshop/cpoptimizer/ConstraintsManager.py
+++ b/pyjobshop/cpoptimizer/ConstraintsManager.py
@@ -109,7 +109,6 @@ class ConstraintsManager:
         alternative variables.
         """
         model, data = self._model, self._data
-        task2machines = utils.task2machines(data)
         task2modes = utils.task2modes(data)
         relevant_constraints = {
             "previous",
@@ -123,24 +122,20 @@ class ConstraintsManager:
             if not task_alt_constraints:
                 continue
 
-            # Find the common machines for both tasks, because the constraints
-            # apply to the task alternative variables on the same machine.
-            machines1 = task2machines[task1]
-            machines2 = task2machines[task2]
+            # Find the common modes for both tasks, because the constraints
+            # apply to the mode variables on the same machine.
+            # TODO this is super complex but I don't have a good idea yet
+            # how to deal with modes and assignment constraints.
+            modes1 = task2modes[task1]
+            modes2 = task2modes[task2]
+            machines1 = [data.modes[mode].machine for mode in modes1]
+            machines2 = [data.modes[mode].machine for mode in modes2]
             machines = set(machines1) & set(machines2)
 
             for machine in machines:
                 seq_var = self._sequence_vars[machine]
-                mode1 = [
-                    mode
-                    for mode in task2modes[task1]
-                    if data.modes[mode].machine == machine
-                ][0]
-                mode2 = [
-                    mode
-                    for mode in task2modes[task2]
-                    if data.modes[mode].machine == machine
-                ][0]
+                mode1 = modes1[machines1.index(machine)]
+                mode2 = modes2[machines2.index(machine)]
                 var1 = self._mode_vars[mode1]
                 var2 = self._mode_vars[mode2]
 

--- a/pyjobshop/cpoptimizer/ConstraintsManager.py
+++ b/pyjobshop/cpoptimizer/ConstraintsManager.py
@@ -45,8 +45,7 @@ class ConstraintsManager:
 
         for task in range(data.num_tasks):
             mode_vars = [
-                self._mode_vars[task, data.modes[mode].machine]
-                for mode in data._task2modes[task]
+                self._mode_vars[mode] for mode in data._task2modes[task]
             ]
             model.add(model.alternative(self._task_vars[task], mode_vars))
 
@@ -127,8 +126,18 @@ class ConstraintsManager:
 
             for machine in machines:
                 seq_var = self._sequence_vars[machine]
-                var1 = self._mode_vars[task1, machine]
-                var2 = self._mode_vars[task2, machine]
+                mode1 = [
+                    mode
+                    for mode in data._task2modes[task1]
+                    if data.modes[mode].machine == machine
+                ][0]
+                mode2 = [
+                    mode
+                    for mode in data._task2modes[task2]
+                    if data.modes[mode].machine == machine
+                ][0]
+                var1 = self._mode_vars[mode1]
+                var2 = self._mode_vars[mode2]
 
                 for constraint in task_alt_constraints:
                     if constraint == "previous":

--- a/pyjobshop/cpoptimizer/VariablesManager.py
+++ b/pyjobshop/cpoptimizer/VariablesManager.py
@@ -1,6 +1,7 @@
 from docplex.cp.expression import CpoIntervalVar, CpoSequenceVar
 from docplex.cp.model import CpoModel
 
+import pyjobshop.utils as utils
 from pyjobshop.ProblemData import ProblemData
 from pyjobshop.Solution import Solution
 from pyjobshop.utils import compute_min_max_durations
@@ -128,9 +129,10 @@ class VariablesManager:
         as previous, before, first, last and permutations.
         """
         model, data = self._model, self._data
+        machine2modes = utils.machine2modes(data)
         variables = []
 
-        for machine, modes in enumerate(data._machine2modes):
+        for machine, modes in enumerate(machine2modes):
             intervals = [self.mode_vars[mode] for mode in modes]
             seq_var = model.sequence_var(name=f"S{machine}", vars=intervals)
             variables.append(seq_var)

--- a/pyjobshop/cpoptimizer/VariablesManager.py
+++ b/pyjobshop/cpoptimizer/VariablesManager.py
@@ -99,11 +99,10 @@ class VariablesManager:
         variables = []
 
         for mode in self._data.modes:
-            task_idx, machine_idx = mode.task, mode.machine
             var = model.interval_var(
-                optional=True, name=f"A{task_idx}_{machine_idx}"
+                optional=True, name=f"A{mode.task}_{mode.machine}"
             )
-            task = data.tasks[task_idx]
+            task = data.tasks[mode.task]
 
             var.set_start_min(task.earliest_start)
             var.set_start_max(min(task.latest_start, data.horizon))

--- a/pyjobshop/cpoptimizer/VariablesManager.py
+++ b/pyjobshop/cpoptimizer/VariablesManager.py
@@ -98,9 +98,9 @@ class VariablesManager:
         model, data = self._model, self._data
         variables = []
 
-        for mode in self._data.modes:
+        for mode in data.modes:
             var = model.interval_var(
-                optional=True, name=f"A{mode.task}_{mode.machine}"
+                optional=True, name=f"M{mode.task}_{mode.machine}"
             )
             task = data.tasks[mode.task]
 

--- a/pyjobshop/ortools/ConstraintsManager.py
+++ b/pyjobshop/ortools/ConstraintsManager.py
@@ -20,7 +20,7 @@ class ConstraintsManager:
         self._data = data
         self._job_vars = vars_manager.job_vars
         self._task_vars = vars_manager.task_vars
-        self._task_alt_vars = vars_manager.task_alt_vars
+        self._task_alt_vars = vars_manager.mode_vars
         self._sequence_vars = vars_manager.sequence_vars
 
     def _job_spans_tasks(self):
@@ -72,7 +72,7 @@ class ConstraintsManager:
 
         for machine in range(data.num_machines):
             seq_var = self._sequence_vars[machine]
-            model.add_no_overlap([var.interval for var in seq_var.task_alts])
+            model.add_no_overlap([var.interval for var in seq_var.modes])
 
     def _activate_setup_times(self):
         """
@@ -151,8 +151,8 @@ class ConstraintsManager:
                     if constraint == "previous":
                         sequence.activate(model)
 
-                        idx1 = sequence.task_alts.index(var1)
-                        idx2 = sequence.task_alts.index(var2)
+                        idx1 = sequence.modes.index(var1)
+                        idx2 = sequence.modes.index(var2)
                         arc = sequence.arcs[idx1, idx2]
 
                         # arc <=> var1.is_present & var2.is_present
@@ -173,8 +173,8 @@ class ConstraintsManager:
                         model.add_implication(both_present, var2.is_present)
 
                         # Schedule var1 before var2 when both are present.
-                        idx1 = sequence.task_alts.index(var1)
-                        idx2 = sequence.task_alts.index(var2)
+                        idx1 = sequence.modes.index(var1)
+                        idx2 = sequence.modes.index(var2)
                         rank1 = sequence.ranks[idx1]
                         rank2 = sequence.ranks[idx2]
 
@@ -201,7 +201,7 @@ class ConstraintsManager:
                 # (expensive) circuit constraints.
                 continue
 
-            task_alt_vars = sequence.task_alts
+            task_alt_vars = sequence.modes
             starts = sequence.starts
             ends = sequence.ends
             ranks = sequence.ranks

--- a/pyjobshop/ortools/ConstraintsManager.py
+++ b/pyjobshop/ortools/ConstraintsManager.py
@@ -1,6 +1,7 @@
 import numpy as np
 from ortools.sat.python.cp_model import CpModel
 
+import pyjobshop.utils as utils
 from pyjobshop.ProblemData import ProblemData
 
 from .VariablesManager import VariablesManager
@@ -41,11 +42,12 @@ class ConstraintsManager:
         exactly one mode.
         """
         model, data = self._model, self._data
+        task2modes = utils.task2modes(data)
 
         for task in range(data.num_tasks):
             presences = []
 
-            for mode in data._task2modes[task]:
+            for mode in task2modes[task]:
                 main = self._task_vars[task]
                 opt = self._mode_vars[mode]
                 is_present = opt.is_present
@@ -128,6 +130,8 @@ class ConstraintsManager:
             "same_machine",
             "different_machine",
         }
+        task2machines = utils.task2machines(data)
+        task2modes = utils.task2modes(data)
 
         for (task1, task2), constraints in data.constraints.items():
             task_alt_constraints = set(constraints) & relevant_constraints
@@ -136,20 +140,20 @@ class ConstraintsManager:
 
             # Find the common machines for both tasks, because the constraints
             # apply to the task alternative variables on the same machine.
-            machines1 = data.task2machines[task1]
-            machines2 = data.task2machines[task2]
+            machines1 = task2machines[task1]
+            machines2 = task2machines[task2]
             machines = set(machines1) & set(machines2)
 
             for machine in machines:
                 sequence = self._sequence_vars[machine]
                 mode1 = [
                     mode
-                    for mode in data._task2modes[task1]
+                    for mode in task2modes[task1]
                     if data.modes[mode].machine == machine
                 ][0]
                 mode2 = [
                     mode
-                    for mode in data._task2modes[task2]
+                    for mode in task2modes[task2]
                     if data.modes[mode].machine == machine
                 ][0]
                 var1 = self._mode_vars[mode1]

--- a/pyjobshop/ortools/ConstraintsManager.py
+++ b/pyjobshop/ortools/ConstraintsManager.py
@@ -124,38 +124,33 @@ class ConstraintsManager:
         alternative variables.
         """
         model, data = self._model, self._data
+        task2modes = utils.task2modes(data)
         relevant_constraints = {
             "previous",
             "before",
             "same_machine",
             "different_machine",
         }
-        task2machines = utils.task2machines(data)
-        task2modes = utils.task2modes(data)
 
         for (task1, task2), constraints in data.constraints.items():
             task_alt_constraints = set(constraints) & relevant_constraints
             if not task_alt_constraints:
                 continue
 
-            # Find the common machines for both tasks, because the constraints
-            # apply to the task alternative variables on the same machine.
-            machines1 = task2machines[task1]
-            machines2 = task2machines[task2]
+            # Find the common modes for both tasks, because the constraints
+            # apply to the mode variables on the same machine.
+            # TODO this is super complex but I don't have a good idea yet
+            # how to deal with modes and assignment constraints.
+            modes1 = task2modes[task1]
+            modes2 = task2modes[task2]
+            machines1 = [data.modes[mode].machine for mode in modes1]
+            machines2 = [data.modes[mode].machine for mode in modes2]
             machines = set(machines1) & set(machines2)
 
             for machine in machines:
                 sequence = self._sequence_vars[machine]
-                mode1 = [
-                    mode
-                    for mode in task2modes[task1]
-                    if data.modes[mode].machine == machine
-                ][0]
-                mode2 = [
-                    mode
-                    for mode in task2modes[task2]
-                    if data.modes[mode].machine == machine
-                ][0]
+                mode1 = modes1[machines1.index(machine)]
+                mode2 = modes2[machines2.index(machine)]
                 var1 = self._mode_vars[mode1]
                 var2 = self._mode_vars[mode2]
 

--- a/pyjobshop/ortools/Solver.py
+++ b/pyjobshop/ortools/Solver.py
@@ -50,12 +50,13 @@ class Solver:
         """
         tasks = {}
 
-        for (task, machine), var in self._vars.mode_vars.items():
+        for idx, var in enumerate(self._vars.mode_vars):
             if cp_solver.value(var.is_present):
                 start = cp_solver.value(var.start)
                 duration = cp_solver.value(var.duration)
                 end = cp_solver.value(var.end)
-                tasks[task] = TaskData(machine, start, duration, end)
+                mode = self._data.modes[idx]
+                tasks[mode.task] = TaskData(mode.machine, start, duration, end)
 
         return Solution([tasks[idx] for idx in range(self._data.num_tasks)])
 

--- a/pyjobshop/ortools/Solver.py
+++ b/pyjobshop/ortools/Solver.py
@@ -50,7 +50,7 @@ class Solver:
         """
         tasks = {}
 
-        for (task, machine), var in self._vars.task_alt_vars.items():
+        for (task, machine), var in self._vars.mode_vars.items():
             if cp_solver.value(var.is_present):
                 start = cp_solver.value(var.start)
                 duration = cp_solver.value(var.duration)

--- a/pyjobshop/ortools/Solver.py
+++ b/pyjobshop/ortools/Solver.py
@@ -63,7 +63,7 @@ class Solver:
     def solve(
         self,
         time_limit: float = float("inf"),
-        log: bool = False,
+        display: bool = False,
         num_workers: Optional[int] = None,
         initial_solution: Optional[Solution] = None,
         **kwargs,
@@ -75,8 +75,8 @@ class Solver:
         ----------
         time_limit
             The time limit for the solver in seconds.
-        log
-            Whether to log the solver output.
+        display
+            Whether to display the solver output. Default ``False``.
         num_workers
             The number of workers to use for parallel solving. If not set, all
             available CPU cores are used.
@@ -99,7 +99,7 @@ class Solver:
 
         params = {
             "max_time_in_seconds": time_limit,
-            "log_search_progress": log,
+            "log_search_progress": display,
             # 0 means using all available CPU cores.
             "num_workers": num_workers if num_workers is not None else 0,
         }

--- a/pyjobshop/ortools/VariablesManager.py
+++ b/pyjobshop/ortools/VariablesManager.py
@@ -346,7 +346,9 @@ class VariablesManager:
             model.add_hint(task_var.duration, sol_task.duration)
             model.add_hint(task_var.end, sol_task.end)
 
-        for mode, var in zip(data.modes, mode_vars):
+        for idx in range(len(data.modes)):
+            var = mode_vars[idx]
+            mode = data.modes[idx]
             sol_task = solution.tasks[mode.task]
 
             model.add_hint(var.start, sol_task.start)

--- a/pyjobshop/ortools/VariablesManager.py
+++ b/pyjobshop/ortools/VariablesManager.py
@@ -7,6 +7,7 @@ from ortools.sat.python.cp_model import (
     IntVar,
 )
 
+import pyjobshop.utils as utils
 from pyjobshop.ProblemData import ProblemData
 from pyjobshop.Solution import Solution
 from pyjobshop.utils import compute_min_max_durations
@@ -306,7 +307,7 @@ class VariablesManager:
         """
         variables = []
 
-        for modes in self._data._machine2modes:
+        for modes in utils.machine2modes(self._data):
             intervals = [self.mode_vars[mode] for mode in modes]
             variables.append(SequenceVar(intervals))
 

--- a/pyjobshop/utils.py
+++ b/pyjobshop/utils.py
@@ -19,7 +19,8 @@ def compute_min_max_durations(
         The minimum and maximum durations for each task.
     """
     durations: list[list[int]] = [[] for _ in range(data.num_tasks)]
-    for (task, _), duration in data.processing_times.items():
+    for mode in data.modes:
+        task, duration = mode.task, mode.duration
         durations[task].append(duration)
 
     min_durations = [min(durations[task]) for task in range(data.num_tasks)]

--- a/pyjobshop/utils.py
+++ b/pyjobshop/utils.py
@@ -38,13 +38,6 @@ def machine2modes(data):
     return result
 
 
-def task2machines(data):
-    result = [[] for _ in range(data.num_tasks)]
-    for mode in data.modes:
-        bisect.insort(result[mode.task], mode.machine)
-    return result
-
-
 def task2modes(data):
     result = [[] for _ in range(data.num_tasks)]
     for idx, mode in enumerate(data.modes):

--- a/pyjobshop/utils.py
+++ b/pyjobshop/utils.py
@@ -1,3 +1,5 @@
+import bisect
+
 from pyjobshop.ProblemData import ProblemData
 
 
@@ -27,3 +29,24 @@ def compute_min_max_durations(
     max_durations = [max(durations[task]) for task in range(data.num_tasks)]
 
     return min_durations, max_durations
+
+
+def machine2modes(data):
+    result = [[] for _ in range(data.num_machines)]
+    for idx, mode in enumerate(data.modes):
+        bisect.insort(result[mode.machine], idx)
+    return result
+
+
+def task2machines(data):
+    result = [[] for _ in range(data.num_tasks)]
+    for mode in data.modes:
+        bisect.insort(result[mode.task], mode.machine)
+    return result
+
+
+def task2modes(data):
+    result = [[] for _ in range(data.num_tasks)]
+    for idx, mode in enumerate(data.modes):
+        bisect.insort(result[mode.task], idx)
+    return result

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -2,7 +2,7 @@ from numpy.testing import assert_equal
 
 from pyjobshop.constants import MAX_VALUE
 from pyjobshop.Model import Model
-from pyjobshop.ProblemData import Constraint, Objective
+from pyjobshop.ProblemData import Constraint, Mode, Objective
 from pyjobshop.Solution import Solution, TaskData
 
 
@@ -43,7 +43,13 @@ def test_model_to_data():
     assert_equal(data.jobs, [job])
     assert_equal(data.machines, [machine1, machine2])
     assert_equal(data.tasks, [task1, task2])
-    assert_equal(data.processing_times, {(0, 0): 1, (1, 1): 2})
+    assert_equal(
+        data.modes,
+        [
+            Mode(task=0, duration=1, resources=[0]),
+            Mode(task=1, duration=2, resources=[1]),
+        ],
+    )
     assert_equal(
         data.constraints,
         {
@@ -82,7 +88,7 @@ def test_from_data(fjsp):
     assert_equal(m_data.num_jobs, data.num_jobs)
     assert_equal(m_data.num_machines, data.num_machines)
     assert_equal(m_data.num_tasks, data.num_tasks)
-    assert_equal(m_data.processing_times, data.processing_times)
+    assert_equal(m_data.modes, data.modes)
     assert_equal(m_data.constraints, data.constraints)
     assert_equal(m_data.setup_times, data.setup_times)
     assert_equal(m_data.horizon, data.horizon)
@@ -105,7 +111,7 @@ def test_model_to_data_default_values():
     assert_equal(data.jobs, [job])
     assert_equal(data.machines, [machine])
     assert_equal(data.tasks, [task])
-    assert_equal(data.processing_times, {(0, 0): 1})
+    # assert_equal(data.processing_times, {(0, 0): 1}) #TODO
     assert_equal(data.constraints, {})
     assert_equal(data.setup_times, [[[0]]])
     assert_equal(data.horizon, MAX_VALUE)

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -111,7 +111,7 @@ def test_model_to_data_default_values():
     assert_equal(data.jobs, [job])
     assert_equal(data.machines, [machine])
     assert_equal(data.tasks, [task])
-    # assert_equal(data.processing_times, {(0, 0): 1}) #TODO
+    assert_equal(data.modes, [Mode(task=0, duration=1, resources=[0])])
     assert_equal(data.constraints, {})
     assert_equal(data.setup_times, [[[0]]])
     assert_equal(data.horizon, MAX_VALUE)

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -8,6 +8,7 @@ from pyjobshop.ProblemData import (
     Constraint,
     Job,
     Machine,
+    Mode,
     Objective,
     ProblemData,
     Task,
@@ -157,7 +158,11 @@ def test_problem_data_input_parameter_attributes():
     jobs = [Job(tasks=[idx]) for idx in range(5)]
     machines = [Machine() for _ in range(5)]
     tasks = [Task() for _ in range(5)]
-    processing_times = {(i, j): 1 for i in range(5) for j in range(5)}
+    modes = [
+        Mode(task=task, duration=1, resources=[machine])
+        for task in range(5)
+        for machine in range(5)
+    ]
     constraints = {
         key: [Constraint.END_BEFORE_START] for key in ((0, 1), (2, 3), (4, 5))
     }
@@ -169,7 +174,7 @@ def test_problem_data_input_parameter_attributes():
         jobs,
         machines,
         tasks,
-        processing_times,
+        modes,
         constraints,
         setup_times,
         horizon,
@@ -179,7 +184,7 @@ def test_problem_data_input_parameter_attributes():
     assert_equal(data.jobs, jobs)
     assert_equal(data.machines, machines)
     assert_equal(data.tasks, tasks)
-    assert_equal(data.processing_times, processing_times)
+    assert_equal(data.modes, modes)
     assert_equal(data.constraints, constraints)
     assert_equal(data.setup_times, setup_times)
     assert_equal(data.horizon, horizon)
@@ -194,9 +199,14 @@ def test_problem_data_non_input_parameter_attributes():
     jobs = [Job(tasks=[0, 1, 2])]
     machines = [Machine() for _ in range(3)]
     tasks = [Task() for _ in range(3)]
-    processing_times = {(2, 1): 1, (1, 2): 1, (1, 0): 1, (0, 2): 1}
+    modes = [
+        Mode(task=2, duration=1, resources=[1]),
+        Mode(task=1, duration=1, resources=[2]),
+        Mode(task=1, duration=1, resources=[0]),
+        Mode(task=0, duration=1, resources=[2]),
+    ]
 
-    data = ProblemData(jobs, machines, tasks, processing_times)
+    data = ProblemData(jobs, machines, tasks, modes)
 
     # The lists in machine2tasks and task2machines are sorted.
     machine2tasks = [[1], [2], [0, 1]]
@@ -216,8 +226,8 @@ def test_problem_data_default_values():
     jobs = [Job(tasks=[0])]
     machines = [Machine()]
     tasks = [Task()]
-    processing_times = {(0, 0): 1}
-    data = ProblemData(jobs, machines, tasks, processing_times)
+    modes = [Mode(task=0, duration=1, resources=[0])]
+    data = ProblemData(jobs, machines, tasks, modes)
 
     assert_equal(data.constraints, {})
     assert_equal(data.setup_times, np.zeros((1, 1, 1), dtype=int))
@@ -225,39 +235,42 @@ def test_problem_data_default_values():
     assert_equal(data.objective, Objective.makespan())
 
 
-def test_problem_data_job_references_invalid_task():
+def test_problem_data_job_references_unknown_task():
     """
     Tests that an error is raised when a job references an unknown task.
     """
     with assert_raises(ValueError):
-        ProblemData([Job(tasks=[42])], [Machine()], [Task()], {})
+        ProblemData(
+            [Job(tasks=[42])],
+            [Machine()],
+            [Task()],
+            [Mode(0, 1, [0])],
+        )
 
 
-def test_problem_data_task_without_processing_times():
+def test_problem_data_task_without_modes():
     """
-    Tests that an error is raised when a task has no processing times.
+    Tests that an error is raised when a task has no processing modes.
     """
     with assert_raises(ValueError):
-        ProblemData([Job()], [Machine()], [Task()], {})
+        ProblemData([Job()], [Machine()], [Task()], [])
 
 
 @pytest.mark.parametrize(
-    "processing_times, setup_times, horizon",
+    "mode, setup_times, horizon",
     [
-        # Negative processing times.
-        ({(0, 0): -1}, np.ones((1, 1, 1)), 1),
+        # Negative processing mode duration.
+        (Mode(0, -1, [0]), np.ones((1, 1, 1)), 1),
         # Negative setup times.
-        ({(0, 0): 1}, np.ones((1, 1, 1)) * -1, 1),
+        (Mode(0, 1, [0]), np.ones((1, 1, 1)) * -1, 1),
         # Invalid setup times shape.
-        ({(0, 0): 1}, np.ones((2, 2, 2)), 1),
+        (Mode(0, 1, [0]), np.ones((2, 2, 2)), 1),
         # Negative horizon.
-        ({(0, 0): 1}, np.ones((1, 1, 1)), -1),
+        (Mode(0, 1, [0]), np.ones((1, 1, 1)), -1),
     ],
 )
 def test_problem_data_raises_when_invalid_arguments(
-    processing_times: dict[tuple[int, int], int],
-    setup_times: np.ndarray,
-    horizon: int,
+    mode: Mode, setup_times: np.ndarray, horizon: int
 ):
     """
     Tests that the ProblemData class raises an error when invalid arguments are
@@ -268,7 +281,7 @@ def test_problem_data_raises_when_invalid_arguments(
             [Job()],
             [Machine()],
             [Task()],
-            processing_times,
+            modes=[mode],
             setup_times=setup_times.astype(int),
             horizon=horizon,
         )
@@ -286,7 +299,11 @@ def test_problem_data_tardy_objective_without_job_due_dates(
     """
     with assert_raises(ValueError):
         ProblemData(
-            [Job()], [Machine()], [Task()], {(0, 0): 0}, objective=objective
+            [Job()],
+            [Machine()],
+            [Task()],
+            [Mode(0, 0, [0])],
+            objective=objective,
         )
 
 
@@ -300,7 +317,10 @@ def describe_problem_data_replace():
         jobs = [Job(due_date=1, deadline=1), Job(due_date=2, deadline=2)]
         machines = [Machine(name="machine"), Machine(name="machine")]
         tasks = [Task(earliest_start=1), Task(earliest_start=1)]
-        processing_times = {(0, 0): 1, (1, 1): 2}
+        modes = [
+            Mode(task=0, duration=1, resources=[0]),
+            Mode(task=1, duration=2, resources=[1]),
+        ]
         constraints = {(0, 1): [Constraint.END_BEFORE_START]}
         setup_times = np.zeros((2, 2, 2))
         horizon = 1
@@ -310,7 +330,7 @@ def describe_problem_data_replace():
             jobs,
             machines,
             tasks,
-            processing_times,
+            modes,
             constraints,
             setup_times,
             horizon,
@@ -342,7 +362,7 @@ def describe_problem_data_replace():
                 data.tasks[idx].earliest_start,
             )
 
-        assert_equal(new.processing_times, data.processing_times)
+        assert_equal(new.modes, data.modes)
         assert_equal(new.constraints, data.constraints)
         assert_equal(new.setup_times, data.setup_times)
         assert_equal(new.horizon, data.horizon)
@@ -357,7 +377,10 @@ def describe_problem_data_replace():
             jobs=[Job(due_date=2, deadline=2), Job(due_date=1, deadline=1)],
             machines=[Machine(name="new"), Machine(name="new")],
             tasks=[Task(earliest_start=2), Task(earliest_start=2)],
-            processing_times={(0, 0): 2, (1, 1): 1},
+            modes=[
+                Mode(task=0, duration=2, resources=[0]),
+                Mode(task=1, duration=1, resources=[1]),
+            ],
             constraints={(1, 0): [Constraint.END_BEFORE_START]},
             setup_times=np.ones((2, 2, 2)),
             horizon=2,
@@ -380,7 +403,7 @@ def describe_problem_data_replace():
                 new.tasks[idx].earliest_start != data.tasks[idx].earliest_start
             )
 
-        assert_(new.processing_times != data.processing_times)
+        assert_(new.modes != data.modes)
         assert_(new.constraints != data.constraints)
         assert_(not np.array_equal(new.setup_times, data.setup_times))
         assert_(new.horizon != data.horizon)
@@ -669,13 +692,13 @@ def test_constraints(solver, prec_type: Constraint, expected_makespan: int):
     job = model.add_job()
     machines = [model.add_machine() for _ in range(2)]
     tasks = [model.add_task(job=job) for _ in range(2)]
-    processing_times = {
-        (m, t): 2 for m in range(len(machines)) for t in range(len(tasks))
-    }
+    modes = [
+        Mode(task=task, duration=2, resources=[machine])
+        for machine in range(len(machines))
+        for task in range(len(tasks))
+    ]
 
-    data = ProblemData(
-        [job], machines, tasks, processing_times, {(0, 1): [prec_type]}
-    )
+    data = ProblemData([job], machines, tasks, modes, {(0, 1): [prec_type]})
     result = solve(data, solver=solver)
 
     assert_equal(result.objective, expected_makespan)
@@ -852,14 +875,14 @@ def test_total_tardiness(solver: str):
     model = Model()
 
     machine = model.add_machine()
-    processing_times = [2, 4]
+    durations = [2, 4]
     due_dates = [2, 2]
     weights = [2, 10]
 
     for idx in range(2):
         job = model.add_job(weight=weights[idx], due_date=due_dates[idx])
         task = model.add_task(job=job)
-        model.add_processing_time(task, machine, processing_times[idx])
+        model.add_processing_time(task, machine, durations[idx])
 
     model.set_objective(weight_total_tardiness=1)
 
@@ -881,12 +904,12 @@ def test_combined_objective(solver: str):
     model = Model()
 
     machine = model.add_machine()
-    processing_times = [2, 4]
+    durations = [2, 4]
 
     for idx in range(2):
         job = model.add_job(due_date=0)
         task = model.add_task(job=job)
-        model.add_processing_time(task, machine, processing_times[idx])
+        model.add_processing_time(task, machine, durations[idx])
 
     model.set_objective(weight_makespan=10, weight_tardy_jobs=2)
     result = model.solve(solver=solver)

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -208,12 +208,6 @@ def test_problem_data_non_input_parameter_attributes():
 
     data = ProblemData(jobs, machines, tasks, modes)
 
-    # The lists in machine2tasks and task2machines are sorted.
-    machine2tasks = [[1], [2], [0, 1]]
-    task2machines = [[2], [0, 2], [1]]
-    assert_equal(data.machine2tasks, machine2tasks)
-    assert_equal(data.task2machines, task2machines)
-
     assert_equal(data.num_jobs, 1)
     assert_equal(data.num_machines, 3)
     assert_equal(data.num_tasks, 3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from numpy.testing import assert_equal
 
-from pyjobshop.ProblemData import Job, Machine, ProblemData, Task
+from pyjobshop.ProblemData import Job, Machine, Mode, ProblemData, Task
 from pyjobshop.utils import compute_min_max_durations
 
 
@@ -12,7 +12,7 @@ def test_compute_min_max_durations():
         [Job()],
         [Machine(), Machine()],
         [Task(), Task()],
-        processing_times={(0, 0): 1, (0, 1): 10, (1, 1): 0},
+        modes=[Mode(0, 1, [0]), Mode(0, 10, [1]), Mode(1, 0, [1])],
         constraints={},
     )
 


### PR DESCRIPTION
This PR replaces processing times and task alternatives for the more general concept of processing modes. It currently only works for one machine per mode and no demands.

Part of #68.