### PR TITLE
[CP Optimizer] Use functions instead of CpoModel methods

### DIFF
--- a/pyjobshop/cpoptimizer/ConstraintsManager.py
+++ b/pyjobshop/cpoptimizer/ConstraintsManager.py
@@ -1,3 +1,4 @@
+import docplex.cp.modeler as cpo
 import numpy as np
 from docplex.cp.model import CpoModel
 
@@ -35,7 +36,7 @@ class ConstraintsManager:
             job_var = self._job_vars[idx]
             job_task_vars = [self._task_vars[task] for task in job.tasks]
 
-            model.add(model.span(job_var, job_task_vars))
+            model.add(cpo.span(job_var, job_task_vars))
 
     def _select_one_mode(self):
         """
@@ -47,7 +48,7 @@ class ConstraintsManager:
 
         for task in range(data.num_tasks):
             mode_vars = [self._mode_vars[mode] for mode in task2modes[task]]
-            model.add(model.alternative(self._task_vars[task], mode_vars))
+            model.add(cpo.alternative(self._task_vars[task], mode_vars))
 
     def _no_overlap_and_setup_times(self):
         """
@@ -70,9 +71,9 @@ class ConstraintsManager:
             seq_var = self._sequence_vars[machine]
 
             if np.all(setups == 0):  # no setup times
-                model.add(model.no_overlap(seq_var))
+                model.add(cpo.no_overlap(seq_var))
             else:
-                model.add(model.no_overlap(seq_var, setups))
+                model.add(cpo.no_overlap(seq_var, setups))
 
     def _resource_capacity(self):
         """
@@ -87,10 +88,10 @@ class ConstraintsManager:
 
             modes = machine2modes[idx]
             pulses = [
-                model.pulse(self._mode_vars[mode], data.modes[mode].demand)
+                cpo.pulse(self._mode_vars[mode], data.modes[mode].demand)
                 for mode in modes
             ]
-            model.add(model.sum(pulses) <= resource.capacity)
+            model.add(cpo.sum(pulses) <= resource.capacity)
 
     def _task_graph(self):
         """
@@ -104,21 +105,21 @@ class ConstraintsManager:
 
             for constraint in constraints:
                 if constraint == "start_at_start":
-                    expr = model.start_at_start(task1, task2)
+                    expr = cpo.start_at_start(task1, task2)
                 elif constraint == "start_at_end":
-                    expr = model.start_at_end(task1, task2)
+                    expr = cpo.start_at_end(task1, task2)
                 elif constraint == "start_before_start":
-                    expr = model.start_before_start(task1, task2)
+                    expr = cpo.start_before_start(task1, task2)
                 elif constraint == "start_before_end":
-                    expr = model.start_before_end(task1, task2)
+                    expr = cpo.start_before_end(task1, task2)
                 elif constraint == "end_at_start":
-                    expr = model.end_at_start(task1, task2)
+                    expr = cpo.end_at_start(task1, task2)
                 elif constraint == "end_at_end":
-                    expr = model.end_at_end(task1, task2)
+                    expr = cpo.end_at_end(task1, task2)
                 elif constraint == "end_before_start":
-                    expr = model.end_before_start(task1, task2)
+                    expr = cpo.end_before_start(task1, task2)
                 elif constraint == "end_before_end":
-                    expr = model.end_before_end(task1, task2)
+                    expr = cpo.end_before_end(task1, task2)
                 else:
                     continue
 
@@ -162,16 +163,16 @@ class ConstraintsManager:
 
                 for constraint in task_alt_constraints:
                     if constraint == "previous":
-                        expr = model.previous(seq_var, var1, var2)
+                        expr = cpo.previous(seq_var, var1, var2)
                     elif constraint == "before":
-                        expr = model.before(seq_var, var1, var2)
+                        expr = cpo.before(seq_var, var1, var2)
                     elif constraint == "same_machine":
-                        presence1 = model.presence_of(var1)
-                        presence2 = model.presence_of(var2)
+                        presence1 = cpo.presence_of(var1)
+                        presence2 = cpo.presence_of(var2)
                         expr = presence1 == presence2
                     elif constraint == "different_machine":
-                        presence1 = model.presence_of(var1)
-                        presence2 = model.presence_of(var2)
+                        presence1 = cpo.presence_of(var1)
+                        presence2 = cpo.presence_of(var2)
                         expr = presence1 != presence2
 
                     model.add(expr)

--- a/pyjobshop/cpoptimizer/ObjectiveManager.py
+++ b/pyjobshop/cpoptimizer/ObjectiveManager.py
@@ -1,3 +1,4 @@
+import docplex.cp.modeler as cpo
 from docplex.cp.model import CpoExpr, CpoModel
 
 from pyjobshop.ProblemData import Objective, ProblemData
@@ -27,61 +28,59 @@ class ObjectiveManager:
         """
         Returns an expression representing the makespan of the model.
         """
-        return self._model.max(
-            self._model.end_of(var) for var in self._task_vars
-        )
+        return cpo.max(cpo.end_of(var) for var in self._task_vars)
 
     def _tardy_jobs_expr(self) -> CpoExpr:
         """
         Returns an expression representing the number of tardy jobs.
         """
-        m, data = self._model, self._data
+        data = self._data
         exprs = []
 
         for job, var in zip(data.jobs, self._job_vars):
-            is_tardy = m.greater(m.end_of(var) - job.due_date, 0)
+            is_tardy = cpo.greater(cpo.end_of(var) - job.due_date, 0)
             exprs.append(job.weight * is_tardy)
 
-        return m.sum(exprs)
+        return cpo.sum(exprs)  # type: ignore
 
     def _total_completion_time_expr(self) -> CpoExpr:
         """
         Returns an expression representing the total completion time of jobs.
         """
-        m, data = self._model, self._data
+        data = self._data
         total = []
 
         for job, var in zip(data.jobs, self._job_vars):
-            completion_time = m.end_of(var)
+            completion_time = cpo.end_of(var)
             total.append(job.weight * completion_time)
 
-        return m.sum(total)
+        return cpo.sum(total)  # type: ignore
 
     def _total_tardiness_expr(self) -> CpoExpr:
         """
         Returns an expression representing the total tardiness of jobs.
         """
-        m, data = self._model, self._data
+        data = self._data
         total = []
 
         for job, var in zip(data.jobs, self._job_vars):
-            tardiness = m.max(0, m.end_of(var) - job.due_date)
+            tardiness = cpo.max(0, cpo.end_of(var) - job.due_date)
             total.append(job.weight * tardiness)
 
-        return m.sum(total)
+        return cpo.sum(total)  # type: ignore
 
     def _total_earliness_expr(self) -> CpoExpr:
         """
         Returns an expression representing the total earliness of jobs.
         """
-        m, data = self._model, self._data
+        data = self._data
         total = []
 
         for job, var in zip(data.jobs, self._job_vars):
-            earliness = m.max(0, job.due_date - m.end_of(var))
+            earliness = cpo.max(0, job.due_date - cpo.end_of(var))
             total.append(job.weight * earliness)
 
-        return m.sum(total)
+        return cpo.sum(total)  # type: ignore
 
     def _objective_expr(self, objective: Objective) -> CpoExpr:
         """


### PR DESCRIPTION
The CpoModel methods are not correctly typed, so IDEs are unable to show docstrings for those methods. This PR replaces the methods with the functions that are correctly type hinted.