### PR TITLE
Optional dependency groups

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.22"
+          version: "0.4.27"
 
       - name: Install Python version
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras --group dev
 
       - name: Cache pre-commit
         uses: actions/cache@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.22"
+          version: "0.4.27"
 
       - run: uv python install 3.11
       - run: uv build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - uv sync --all-extras --dev
+    - uv sync --all-extras --group docs --group examples
     - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs/source $READTHEDOCS_OUTPUT/html
 sphinx:
   configuration: docs/source/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "ortools>=9.10.4067",
+    "ortools>=9.10.4067,<10",
     "matplotlib>=3.9.2",
     "fjsplib",
     "enum-tools>=0.12.0",
@@ -28,24 +28,22 @@ cplex = [
     "cplex>=22.1.1.2",
 ]
 
-
-[tool.uv]
-dev-dependencies = [
-    # Dev
+[depedency-groups]
+dev = [
     "pre-commit>=3.8.0",
     "pytest>=8.3.2",
     "pytest-cov>=5.0.0",
     "pytest-describe>=2.2.0",
     "codecov>=2.1.13",
-    # Docs
+]
+docs = [
     "sphinx>=7.4.7",
     "nbsphinx>=0.9.5",
     "numpydoc>=1.8.0",
     "sphinx-immaterial>=0.12.2",
     "enum-tools[sphinx]>=0.12.0",
-    # Examples
-    "jupyterlab>=4.2.4",
 ]
+examples = ["jupyterlab>=4.2.4"]
 
 [tool.uv.sources]
 fjsplib = { git = "https://github.com/PyJobShop/FJSPLIB.git", rev = "75b2d18" }


### PR DESCRIPTION
Maintenance chore. UV now supports optional dependency groups as specified in [PEP 735](https://peps.python.org/pep-0735/).