### PR TITLE
Upgrade CPLEX to be Python 3.12 compatible

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,14 +26,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install the project
-        run: |
-          if [ "${{ matrix.python-version }}" != "3.12" ]; then
-            uv sync --all-extras
-          else
-            # CPLEX does not distribute binaries for Python 3.12, so we do not
-            # install its extras dependencies for this version.
-            uv sync
-          fi
+        run: uv sync --all-extras
 
       - name: Cache pre-commit
         uses: actions/cache@v3
@@ -50,14 +43,7 @@ jobs:
         run: uv run pre-commit run --all-files
 
       - name: Run tests
-        run: |
-          if [ "${{ matrix.python-version }}" != "3.12" ]; then
-            uv run pytest --solvers ortools cpoptimizer
-          else
-          # CPLEX does not distribute binaries for Python 3.12,
-          # so we only test ortools on 3.11.
-            uv run pytest --solvers ortools
-          fi
+        run: uv run pytest --solvers ortools cpoptimizer
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/docs/source/setup/installation.rst
+++ b/docs/source/setup/installation.rst
@@ -27,7 +27,7 @@ Installing CP Optimizer
 PyJobShop includes OR-Tools' CP-SAT solver by default, an open-source constraint programming solver.
 Additionally, PyJobShop can be integrated with IBM ILOG CP Optimizer, a commercial constraint programming solver.
 
-To use PyJobShop with CP Optimizer, follow one of the following two steps based on whether you already have CP Optimizer installed:
+To use PyJobShop with CP Optimizer, take one of the following two steps:
 
 1. **If you already have CP Optimizer installed:**
 
@@ -49,10 +49,6 @@ To use PyJobShop with CP Optimizer, follow one of the following two steps based 
       pip install pyjobshop[docplex,cplex]
 
    The ``cplex`` library installs a free edition of CP Optimizer that is capable of solving models with up to 1000 variables and 1000 constraints. For larger models, you need a paid or academic version of CP Optimizer.
-
-   .. warning::
-
-      The free community edition of CP Optimizer can only installed with Python versions 3.9-3.11.
 
 Obtaining the academic version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ docplex = [
     "docplex>=2.28.240",
 ]
 cplex = [
-    "cplex>=22.1.1.2",
+    "cplex>=22.1.2",
 ]
 
 


### PR DESCRIPTION
Maintenance chore. New `cplex` is now compatible with Python 3.12.