### PR TITLE
Remove horizon

### DIFF
--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -35,7 +35,6 @@ class Model:
         )
 
         self._setup_times: dict[tuple[int, int, int], int] = {}
-        self._horizon: int = MAX_VALUE
         self._objective: Objective = Objective.makespan()
 
         self._id2job: dict[int, int] = {}
@@ -161,7 +160,6 @@ class Model:
                         duration=duration,
                     )
 
-        model.set_horizon(data.horizon)
         model.set_objective(
             weight_makespan=data.objective.weight_makespan,
             weight_tardy_jobs=data.objective.weight_tardy_jobs,
@@ -197,7 +195,6 @@ class Model:
             modes=self._modes,
             constraints=self._constraints,
             setup_times=setup,
-            horizon=self._horizon,
             objective=self._objective,
         )
 
@@ -491,17 +488,6 @@ class Model:
         task_idx2 = self._id2task[id(task2)]
 
         self._setup_times[machine_idx, task_idx1, task_idx2] = duration
-
-    def set_horizon(self, horizon: int):
-        """
-        Sets the horizon of the model.
-
-        Parameters
-        ----------
-        horizon
-            The horizon.
-        """
-        self._horizon = horizon
 
     def set_objective(
         self,

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -502,8 +502,6 @@ class ProblemData:
         Sequence-dependent setup times between tasks on a given resource. The
         first dimension of the array is indexed by the resource index. The last
         two dimensions of the array are indexed by task indices.
-    horizon
-        The horizon value. Default ``MAX_VALUE``.
     objective
         The objective function. Default is minimizing the makespan.
     """
@@ -516,7 +514,6 @@ class ProblemData:
         modes: list[Mode],
         constraints: Optional[_ConstraintsType] = None,
         setup_times: Optional[np.ndarray] = None,
-        horizon: int = MAX_VALUE,
         objective: Optional[Objective] = None,
     ):
         self._jobs = jobs
@@ -525,7 +522,6 @@ class ProblemData:
         self._modes = modes
         self._constraints = constraints if constraints is not None else {}
         self._setup_times = setup_times
-        self._horizon = horizon
         self._objective = (
             objective if objective is not None else Objective.makespan()
         )
@@ -593,9 +589,6 @@ class ProblemData:
                     msg = "Setup times only allowed for machines."
                     raise ValueError(msg)
 
-        if self.horizon < 0:
-            raise ValueError("Horizon must be non-negative.")
-
         if (
             self.objective.weight_tardy_jobs > 0
             or self.objective.weight_total_tardiness > 0
@@ -615,7 +608,6 @@ class ProblemData:
         modes: Optional[list[Mode]] = None,
         constraints: Optional[_ConstraintsType] = None,
         setup_times: Optional[np.ndarray] = None,
-        horizon: Optional[int] = None,
         objective: Optional[Objective] = None,
     ) -> "ProblemData":
         """
@@ -636,8 +628,6 @@ class ProblemData:
             Optional constraints between tasks.
         setup_times
             Optional sequence-dependent setup times.
-        horizon
-            Optional horizon value.
         objective
             Optional objective function.
 
@@ -656,7 +646,6 @@ class ProblemData:
         modes = _deepcopy_if_none(modes, self.modes)
         constraints = _deepcopy_if_none(constraints, self.constraints)
         setup_times = _deepcopy_if_none(setup_times, self.setup_times)
-        horizon = _deepcopy_if_none(horizon, self.horizon)
         objective = _deepcopy_if_none(objective, self.objective)
 
         return ProblemData(
@@ -666,7 +655,6 @@ class ProblemData:
             modes=modes,
             constraints=constraints,
             setup_times=setup_times,
-            horizon=horizon,
             objective=objective,
         )
 
@@ -714,14 +702,6 @@ class ProblemData:
         indices are the task indices.
         """
         return self._setup_times
-
-    @property
-    def horizon(self) -> int:
-        """
-        The time horizon of this instance. This is an upper bound on the
-        completion time of all tasks.
-        """
-        return self._horizon
 
     @property
     def objective(self) -> Objective:

--- a/pyjobshop/solvers/cpoptimizer/Variables.py
+++ b/pyjobshop/solvers/cpoptimizer/Variables.py
@@ -9,6 +9,7 @@ from docplex.cp.expression import (
 from docplex.cp.model import CpoModel
 
 import pyjobshop.solvers.utils as utils
+from pyjobshop.constants import MAX_VALUE
 from pyjobshop.ProblemData import Machine, ProblemData
 from pyjobshop.Solution import Solution
 
@@ -65,7 +66,7 @@ class Variables:
             var = interval_var(name=f"J{job}")
 
             var.set_start_min(job.release_date)
-            var.set_end_max(min(job.deadline, self._data.horizon))
+            var.set_end_max(min(job.deadline, MAX_VALUE))
 
             variables.append(var)
             self._model.add(var)
@@ -84,16 +85,14 @@ class Variables:
             var = interval_var(name=f"T{task}")
 
             var.set_start_min(task.earliest_start)
-            var.set_start_max(min(task.latest_start, data.horizon))
+            var.set_start_max(min(task.latest_start, MAX_VALUE))
 
             var.set_end_min(task.earliest_end)
-            var.set_end_max(min(task.latest_end, data.horizon))
+            var.set_end_max(min(task.latest_end, MAX_VALUE))
 
             var.set_size_min(min(task_durations[idx]))
             var.set_size_max(
-                max(task_durations[idx])
-                if task.fixed_duration
-                else data.horizon
+                max(task_durations[idx]) if task.fixed_duration else MAX_VALUE
             )
 
             variables.append(var)
@@ -113,16 +112,16 @@ class Variables:
             task = data.tasks[mode.task]
 
             var.set_start_min(task.earliest_start)
-            var.set_start_max(min(task.latest_start, data.horizon))
+            var.set_start_max(min(task.latest_start, MAX_VALUE))
 
             var.set_end_min(task.earliest_end)
-            var.set_end_max(min(task.latest_end, data.horizon))
+            var.set_end_max(min(task.latest_end, MAX_VALUE))
 
             if task.fixed_duration:
                 var.set_size(mode.duration)
             else:
                 var.set_size_min(mode.duration)
-                var.set_size_max(data.horizon)
+                var.set_size_max(MAX_VALUE)
 
             variables.append(var)
             self._model.add(var)

--- a/pyjobshop/solvers/ortools/Objective.py
+++ b/pyjobshop/solvers/ortools/Objective.py
@@ -4,6 +4,7 @@ from ortools.sat.python.cp_model import (
     LinearExprT,
 )
 
+from pyjobshop.constants import MAX_VALUE
 from pyjobshop.ProblemData import Objective as DataObjective
 from pyjobshop.ProblemData import ProblemData
 
@@ -29,7 +30,7 @@ class Objective:
         """
         Returns an expression representing the makespan of the model.
         """
-        makespan = self._model.new_int_var(0, self._data.horizon, "makespan")
+        makespan = self._model.new_int_var(0, MAX_VALUE, "makespan")
         completion_times = [var.end for var in self._task_vars]
         self._model.add_max_equality(makespan, completion_times)
         return makespan
@@ -59,7 +60,7 @@ class Objective:
         flow_time_vars = []
 
         for job, var in zip(data.jobs, self._job_vars):
-            flow_time = model.new_int_var(0, data.horizon, f"flow_time_{job}")
+            flow_time = model.new_int_var(0, MAX_VALUE, f"flow_time_{job}")
             model.add_max_equality(flow_time, [0, var.end - job.release_date])
             flow_time_vars.append(flow_time)
 
@@ -75,7 +76,7 @@ class Objective:
 
         for job, var in zip(data.jobs, self._job_vars):
             assert job.due_date is not None
-            tardiness = model.new_int_var(0, data.horizon, f"tardiness_{job}")
+            tardiness = model.new_int_var(0, MAX_VALUE, f"tardiness_{job}")
             model.add_max_equality(tardiness, [0, var.end - job.due_date])
             tardiness_vars.append(tardiness)
 
@@ -91,7 +92,7 @@ class Objective:
 
         for job, var in zip(data.jobs, self._job_vars):
             assert job.due_date is not None
-            earliness = model.new_int_var(0, data.horizon, f"earliness_{job}")
+            earliness = model.new_int_var(0, MAX_VALUE, f"earliness_{job}")
             model.add_max_equality(earliness, [0, job.due_date - var.end])
             earliness_vars.append(earliness)
 
@@ -107,11 +108,11 @@ class Objective:
 
         for job, var in zip(data.jobs, self._job_vars):
             assert job.due_date is not None
-            tardiness = model.new_int_var(0, data.horizon, f"tardiness_{job}")
+            tardiness = model.new_int_var(0, MAX_VALUE, f"tardiness_{job}")
             model.add_max_equality(tardiness, [0, var.end - job.due_date])
             tardiness_vars.append(job.weight * tardiness)
 
-        max_tardiness = model.new_int_var(0, data.horizon, "max_tardiness")
+        max_tardiness = model.new_int_var(0, MAX_VALUE, "max_tardiness")
         model.add_max_equality(max_tardiness, tardiness_vars)
         return max_tardiness
 
@@ -125,14 +126,12 @@ class Objective:
         for job, var in zip(data.jobs, self._job_vars):
             assert job.due_date is not None
             lateness = model.new_int_var(
-                -data.horizon, data.horizon, f"lateness_{job}"
+                -MAX_VALUE, MAX_VALUE, f"lateness_{job}"
             )
             model.add(lateness == var.end - job.due_date)
             lateness_vars.append(job.weight * lateness)
 
-        max_lateness = model.new_int_var(
-            -data.horizon, data.horizon, "max_lateness"
-        )
+        max_lateness = model.new_int_var(-MAX_VALUE, MAX_VALUE, "max_lateness")
         model.add_max_equality(max_lateness, lateness_vars)
         return max_lateness
 

--- a/pyjobshop/solvers/ortools/Variables.py
+++ b/pyjobshop/solvers/ortools/Variables.py
@@ -10,6 +10,7 @@ from ortools.sat.python.cp_model import (
 )
 
 import pyjobshop.solvers.utils as utils
+from pyjobshop.constants import MAX_VALUE
 from pyjobshop.ProblemData import Machine, ProblemData
 from pyjobshop.Solution import Solution
 
@@ -185,17 +186,17 @@ class Variables:
             name = f"J{idx}"
             start = model.new_int_var(
                 lb=job.release_date,
-                ub=data.horizon,
+                ub=MAX_VALUE,
                 name=f"{name}_start",
             )
             duration = model.new_int_var(
                 lb=0,
-                ub=min(job.deadline - job.release_date, data.horizon),
+                ub=min(job.deadline - job.release_date, MAX_VALUE),
                 name=f"{name}_duration",
             )
             end = model.new_int_var(
                 lb=0,
-                ub=min(job.deadline, data.horizon),
+                ub=min(job.deadline, MAX_VALUE),
                 name=f"{name}_end",
             )
             interval = model.new_interval_var(
@@ -217,7 +218,7 @@ class Variables:
             name = f"T{idx}"
             start = model.new_int_var(
                 lb=task.earliest_start,
-                ub=min(task.latest_start, data.horizon),
+                ub=min(task.latest_start, MAX_VALUE),
                 name=f"{name}_start",
             )
             if task.fixed_duration:
@@ -227,12 +228,12 @@ class Variables:
             else:
                 duration = model.new_int_var(
                     lb=min(task_durations[idx]),
-                    ub=data.horizon,
+                    ub=MAX_VALUE,
                     name=f"{name}_duration",
                 )
             end = model.new_int_var(
                 lb=task.earliest_end,
-                ub=min(task.latest_end, data.horizon),
+                ub=min(task.latest_end, MAX_VALUE),
                 name=f"{name}_end",
             )
             interval = model.new_interval_var(
@@ -256,17 +257,17 @@ class Variables:
             name = f"M{idx}_{mode.task}"
             start = model.new_int_var(
                 lb=task.earliest_start,
-                ub=min(task.latest_start, data.horizon),
+                ub=min(task.latest_start, MAX_VALUE),
                 name=f"{name}_start",
             )
             duration = model.new_int_var(
                 lb=mode.duration,
-                ub=mode.duration if task.fixed_duration else data.horizon,
+                ub=mode.duration if task.fixed_duration else MAX_VALUE,
                 name=f"{name}_duration",
             )
             end = model.new_int_var(
                 lb=task.earliest_end,
-                ub=min(task.latest_end, data.horizon),
+                ub=min(task.latest_end, MAX_VALUE),
                 name=f"{name}_start",
             )
             is_present = model.new_bool_var(f"{name}_is_present")

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -1,7 +1,6 @@
 import numpy as np
 from numpy.testing import assert_equal
 
-from pyjobshop.constants import MAX_VALUE
 from pyjobshop.Model import Model
 from pyjobshop.ProblemData import (
     Constraint,
@@ -44,7 +43,6 @@ def test_model_to_data():
     model.add_setup_time(machine1, task1, task2, 3)
     model.add_setup_time(machine2, task1, task2, 4)
 
-    model.set_horizon(100)
     model.set_objective(weight_total_flow_time=1)
 
     data = model.data()
@@ -80,7 +78,6 @@ def test_model_to_data():
         },
     )
     assert_equal(data.setup_times, [[[0, 3], [0, 0]], [[0, 4], [0, 0]]])
-    assert_equal(data.horizon, 100)
     assert_equal(data.objective, Objective.total_flow_time())
 
 
@@ -117,7 +114,6 @@ def test_from_data():
                 np.ones((3, 3)),  # machine
             ]
         ),
-        horizon=100,
         objective=Objective(
             weight_makespan=2,
             weight_tardy_jobs=3,
@@ -138,7 +134,6 @@ def test_from_data():
     assert_equal(m_data.modes, data.modes)
     assert_equal(m_data.constraints, data.constraints)
     assert_equal(m_data.setup_times, data.setup_times)
-    assert_equal(m_data.horizon, data.horizon)
     assert_equal(m_data.objective, data.objective)
 
 
@@ -161,7 +156,6 @@ def test_model_to_data_default_values():
     assert_equal(data.modes, [Mode(task=0, resources=[0], duration=1)])
     assert_equal(data.constraints, {})
     assert_equal(data.setup_times, None)
-    assert_equal(data.horizon, MAX_VALUE)
     assert_equal(data.objective, Objective.makespan())
 
 


### PR DESCRIPTION
This PR removes the horizon argument to ProblemData. I have never really used this and the benchmarks don't improve by setting this value (to some simple upper bound). So it's just better to remove it altogether. If users still want to set a horizon value, they can do so by setting `Task.latest_end`.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyjobshop.readthedocs.io/latest/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyJobShop's MIT license.
  Please check that this PR can be included into PyJobShop under the MIT license.

</details>
