### PR TITLE
WIP: Enhance Gantt chart plotting by incorporating resource capacities

### DIFF
--- a/pyjobshop/plot/plot_machine_gantt.py
+++ b/pyjobshop/plot/plot_machine_gantt.py
@@ -4,7 +4,7 @@ from typing import Optional
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 
-from pyjobshop.ProblemData import ProblemData
+from pyjobshop.ProblemData import ProblemData, Renewable, NonRenewable
 from pyjobshop.Solution import Solution
 
 from .utils import get_colors as _get_colors
@@ -50,40 +50,98 @@ def plot_machine_gantt(
         if task.job is not None:
             task2color[idx] = colors[task.job % len(colors)]
 
-    for idx, task_data in enumerate(solution.tasks):
+    # Calculate the base y-position for each resource
+    resource_base_y = {}
+    resource_lanes = {}  # For each resource, track the occupation of each lane
+    for resource_idx in resources:
+        resource = data.resources[resource_idx]
+        capacity = resource.capacity if isinstance(resource, (Renewable, NonRenewable)) else 1
+        resource_base_y[resource_idx] = sum(
+            data.resources[r].capacity if isinstance(data.resources[r], (Renewable, NonRenewable)) else 1
+            for r in resources if r < resource_idx
+        )
+        # For each lane, keep a list of (start, end) tuples
+        resource_lanes[resource_idx] = [[] for _ in range(capacity)]
+
+    # Sort tasks by start time to process them in chronological order
+    sorted_tasks = sorted(enumerate(solution.tasks), key=lambda x: x[1].start)
+
+    for task_idx, task_data in sorted_tasks:
         kwargs = {
-            "color": task2color[idx],
+            "color": task2color[task_idx],
             "linewidth": 1,
             "edgecolor": "black",
             "alpha": 0.75,
         }
         duration = task_data.end - task_data.start
-        for resource in task_data.resources:
-            if resource not in resources:
+        mode = data.modes[task_data.mode]
+
+        for resource_idx, demand in zip(mode.resources, mode.demands):
+            if resource_idx not in resources:
                 continue  # skip resources not in the order
 
+            resource = data.resources[resource_idx]
+            capacity = resource.capacity if isinstance(resource, (Renewable, NonRenewable)) else 1
+
+            # Calculate the height of this task bar
+            if capacity > 1:
+                height = demand / capacity
+            else:
+                height = 1.0
+
+            # Assign the task to the first available lane for its entire duration
+            lane_found = False
+            for lane_idx, lane in enumerate(resource_lanes[resource_idx]):
+                # Check if this lane is free for the entire duration
+                if all(task_data.end <= s or task_data.start >= e for (s, e) in lane):
+                    lane.append((task_data.start, task_data.end))
+                    lane_found = True
+                    break
+            if not lane_found:
+                # Should not happen if demand <= capacity and model is feasible
+                lane_idx = 0  # fallback to first lane
+                resource_lanes[resource_idx][lane_idx].append((task_data.start, task_data.end))
+
+            base_y = resource_base_y[resource_idx]
+            y_position = base_y + lane_idx
+            height = 1.0  # always use full height for each lane
+
             ax.barh(
-                resources.index(resource),
+                y_position,
                 duration,
                 left=task_data.start,
+                height=height,
                 **kwargs,
             )
 
             if plot_labels:
                 ax.text(
                     task_data.start + duration / 2,
-                    resources.index(resource),
-                    data.tasks[idx].name or f"{idx}",
+                    y_position + height / 2,
+                    data.tasks[task_idx].name or f"{task_idx}",
                     ha="center",
                     va="center",
+                    fontsize=8,
                 )
 
-    labels = [
-        data.resources[idx].name or f"Machine {idx}" for idx in resources
-    ]
+    # Set y-axis ticks and labels
+    y_ticks = []
+    y_labels = []
+    current_y = 0
+    for resource_idx in resources:
+        resource = data.resources[resource_idx]
+        capacity = resource.capacity if isinstance(resource, (Renewable, NonRenewable)) else 1
+        base_y = current_y
+        y_ticks.append(base_y)
+        resource_name = resource.name or f"Machine {resource_idx}"
+        if capacity > 1:
+            y_labels.append(f"{resource_name} (cap={capacity})")
+        else:
+            y_labels.append(resource_name)
+        current_y += capacity
 
-    ax.set_yticks(ticks=range(len(labels)), labels=labels)
-    ax.set_ylim(ax.get_ylim()[::-1])
+    ax.set_yticks(ticks=y_ticks, labels=y_labels)
+    ax.set_ylim(current_y + 0.5, -0.5)  # Ensure all bars are fully visible, including the first and last
 
     ax.set_xlim(0, ax.get_xlim()[1])  # start time at zero
     ax.set_xlabel("Time")

--- a/pyjobshop/plot/plot_machine_gantt_plotly.py
+++ b/pyjobshop/plot/plot_machine_gantt_plotly.py
@@ -1,0 +1,115 @@
+from typing import Optional
+from datetime import datetime, timedelta
+
+import matplotlib.colors as mcolors
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+from ..ProblemData import ProblemData
+
+
+def get_plotly_colors():
+    """
+    Returns a list of RGB colors for Plotly, converting from Matplotlib's
+    'tab20' colormap.
+    """
+    tableau_colors = mcolors.TABLEAU_COLORS
+    plotly_colors = [
+        f"rgb({int(r*255)}, {int(g*255)}, {int(b*255)})"
+        for r, g, b, _ in mcolors.to_rgba_array(
+            [tableau_colors[name] for name in tableau_colors]
+        )
+    ]
+    return plotly_colors
+
+
+def plot_combined_plotly(
+    result: "Result",
+    data: ProblemData,
+    resources: Optional[list[int]] = None,
+):
+    """
+    Plots a machine-based Gantt chart of the solution using Plotly Express.
+
+    Parameters
+    ----------
+    result
+        A result object from the solver, containing the solution.
+    data
+        The problem data instance.
+    resources
+        The resources (by index) to plot. Defaults to all resources.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        A Plotly figure object containing the Gantt chart.
+    """
+    solution = result.best
+
+    if resources is None:
+        resources = list(range(data.num_resources))
+
+    timeline_data = []
+    colors = get_plotly_colors()
+    job_color_map = {}
+    now = datetime.now()
+
+    for task_idx, sol_task in enumerate(solution.tasks):
+        if sol_task.start == sol_task.end:
+            continue
+
+        task_info = data.tasks[task_idx]
+        task_name = task_info.name or f"Task {task_idx}"
+        job_name = "Unassigned"
+
+        if task_info.job is not None:
+            job_name = data.jobs[task_info.job].name
+            if job_name not in job_color_map:
+                job_color_map[job_name] = colors[task_info.job % len(colors)]
+
+        mode = data.modes[sol_task.mode]
+        for resource_idx in mode.resources:
+            if resource_idx in resources:
+                resource_name = (
+                    data.resources[resource_idx].name
+                    or f"Resource {resource_idx}"
+                )
+                duration = sol_task.end - sol_task.start
+                timeline_data.append(
+                    dict(
+                        Task=task_name,
+                        Start=now + timedelta(minutes=sol_task.start),
+                        Finish=now + timedelta(minutes=sol_task.end),
+                        Resource=resource_name,
+                        Job=job_name,
+                        Duration=f"{duration}m",
+                    )
+                )
+
+    if not timeline_data:
+        return go.Figure().update_layout(title_text="No tasks to display.")
+
+    df = pd.DataFrame(timeline_data)
+
+    fig = px.timeline(
+        df,
+        x_start="Start",
+        x_end="Finish",
+        y="Resource",
+        color="Job",
+        hover_name="Task",
+        hover_data=["Duration"],
+        color_discrete_map=job_color_map,
+        title="Machine Gantt Chart",
+    )
+
+    fig.update_yaxes(autorange="reversed")
+    fig.update_layout(
+        xaxis_title="Time",
+        yaxis_title="Machines",
+        height=30 * len(df["Resource"].unique()) + 150,
+    )
+
+    return fig 


### PR DESCRIPTION
This PR enhances the `plot_machine_gantt` function by showing the tasks in a resource with a capacity > 1. These changes make the Gantt chart more informative and visually robust, especially for problems involving multi-capacity resources. This helps users better interpret the schedule and resource utilization. Specifically:

- Y-Axis Labels: For resources with capacity greater than 1, the label now includes the capacity (e.g., Machine A (cap=3)), making it clearer when a resource can process multiple tasks simultaneously.
- Y-Axis Limits: The y-axis limits are set to ensure that all bars, including those at the top and bottom, are fully visible, preventing clipping.
- Ticks and Labels: The y-ticks and labels are aligned with the base of each resource, improving readability.

![machine_gantt](https://github.com/user-attachments/assets/8b26e162-b856-4bc8-aacb-940ced480f19)

This is still WIP, i wanted to open the door to early feedback. At the moment there is still some overlay happening in the resource lanes. 

Testing:
- [x] Verified that Gantt charts render correctly for both single- and multi-capacity resources.
- [x] Checked that all bars and labels are visible and correctly aligned.