### PR TITLE
Remove maximum lateness

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It currently supports the following scheduling problems:
 
 - **Resource environments:** single machines, parallel machines, hybrid flow shops, open shops, job shops, flexible job shops, renewable resources and non-renewable resources.
 - **Constraints:** release dates, deadlines, due dates, multiple modes, sequence-dependent setup times, no-wait, blocking, and arbitrary precedence constraints.
-- **Objective functions:** minimizing makespan, total flow time, number of tardy jobs, total tardiness, total earliness, maximum tardiness, maximum lateness, and total setup times.
+- **Objective functions:** minimizing makespan, total flow time, number of tardy jobs, total tardiness, total earliness, maximum tardiness, and total setup times.
 
 You can find PyJobShop on the Python Package Index under the name `pyjobshop`. 
 To install it, simply run:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ It currently supports the following scheduling problems:
 
 - **Resource environments:** single machines, parallel machines, hybrid flow shops, open shops, job shops, flexible job shops, renewable resources and non-renewable resources.
 - **Constraints:** release dates, deadlines, due dates, multiple modes, sequence-dependent setup times, no-wait, blocking, and arbitrary precedence constraints.
-- **Objective functions:** minimizing makespan, total flow time, number of tardy jobs, total tardiness, total earliness, maximum tardiness, maximum lateness, and total setup times.
+- **Objective functions:** minimizing makespan, total flow time, number of tardy jobs, total tardiness, total earliness, maximum tardiness, and total setup times.
 
 You can find PyJobShop on the Python Package Index under the name ``pyjobshop``.
 To install it, simply run:

--- a/examples/objectives_examples.ipynb
+++ b/examples/objectives_examples.ipynb
@@ -308,20 +308,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "PyJobShop supports the minimization of the weighted sum of the following objectives:\n",
-    "\n",
-    "- **Makespan:** the finish time of the latest task.\n",
-    "- **Number of tardy jobs:** the weighted sum of all tardy jobs, where a job is tardy when it does not meet its due date.\n",
-    "- **Total flow time:** the weighted sum of the length of stay in the system of each job, from their release date to their completion.\n",
-    "- **Total tardiness:** the weighted sum of the tardiness of each job, where the tardiness of a job is the difference between its completion time and its due date, where tardiness is 0 when it is completed before its due date.\n",
-    "- **Total earliness:** the weighted sum of the earliness of each job, where the earliness of a job is the difference between its due date and its completion time, where earliness is 0 when its completion time is after its due date.\n",
-    "- **Maximum tardiness:** the weighted maximum tardiness of all jobs.\n",
-    "- **Maximum lateness:** the weighted maximum lateness of all jobs. The lateness of a job is the difference between its completion time and its due date (in contrast to tardiness, it can be smaller than 0).\n",
-    "- **Total setup time:** the sum of all sequence-dependent setup times between consecutive tasks on each machine.\n",
-    "\n",
-    "The objective weights are captured in the `Objective` class; for more details, see its [API documentation](https://pyjobshop.org/stable/api/pyjobshop.html#pyjobshop.ProblemData.Objective)."
-   ]
+   "source": "PyJobShop supports the minimization of the weighted sum of the following objectives:\n\n- **Makespan:** the finish time of the latest task.\n- **Number of tardy jobs:** the weighted sum of all tardy jobs, where a job is tardy when it does not meet its due date.\n- **Total flow time:** the weighted sum of the length of stay in the system of each job, from their release date to their completion.\n- **Total tardiness:** the weighted sum of the tardiness of each job, where the tardiness of a job is the difference between its completion time and its due date, where tardiness is 0 when it is completed before its due date.\n- **Total earliness:** the weighted sum of the earliness of each job, where the earliness of a job is the difference between its due date and its completion time, where earliness is 0 when its completion time is after its due date.\n- **Maximum tardiness:** the weighted maximum tardiness of all jobs.\n- **Total setup time:** the sum of all sequence-dependent setup times between consecutive tasks on each machine.\n\nThe objective weights are captured in the `Objective` class; for more details, see its [API documentation](https://pyjobshop.org/stable/api/pyjobshop.html#pyjobshop.ProblemData.Objective)."
   },
   {
    "cell_type": "markdown",
@@ -333,31 +320,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "We now explain how the objective value is calculated in general. To that end, let $w_j$ denote the weight of job $j$ and let $w_{\\text{obj}}$ denote the weight of objective $\\text{obj}$ (see the previous section for an overview of all objectives). We denote the contribution of job $j$ to the objective $\\text{obj}$ in schedule $s$ as $\\text{contribution}(j, \\text{obj}, s)$. The value of the makespan of schedule $s$ is denoted by $\\text{makespan}(s)$ and the value of the total setup time of schedule $s$ is denoted by $\\text{TST}(s)$. The general objective value for schedule $s$ is calculated in PyJobShop as follows:\n",
-    "\\begin{equation}\n",
-    "\\text{objective}(s) = w_{\\text{makespan}} \\cdot \\text{makespan}(s) + w_{\\text{TST}} \\cdot \\text{TST}(s) + \\sum_{\\text{obj} \\neq \\text{makespan}, \\text{TST}} w_{\\text{obj}} \\cdot \\sum_{j} w_j \\cdot \\text{contribution}(j, \\text{obj}, s).\n",
-    "\\end{equation}\n",
-    "The following simple example of two jobs, with given weights, release date, and start and end times, shows how the objective components are calculated and combined in the different objective values. In particular, the following table shows the objective component values for the two jobs.\n",
-    "\n",
-    "| **Job** | **Weights** | **Release date** | **Start time** | **End time** | **Due date** | **Tardy? (1=yes, 0=no)** | **Flow time** | **Tardiness** | **Earliness** | **Lateness** |\n",
-    "|:-------:|:-----------:|:----------------:|:--------------:|:------------:|:------------:|:------------------------:|:-------------:|:-------------:|:-------------:|:------------:|\n",
-    "|    1    |      3      |         1        |        2       |       4      |       3      |             1            |       3       |       1       |       0       |       1      |\n",
-    "|    2    |      1      |         0        |        0       |       2      |       4      |             0            |       2       |       0       |       2       |      -2      |\n",
-    "\n",
-    "Based on these objective component values, the following table shows the different objective values for the example.\n",
-    "\n",
-    "| **Objective**            | **Value** |\n",
-    "|--------------------------|:---------:|\n",
-    "| **Makespan**             |     4     |\n",
-    "| **Number of tardy jobs** |     3     |\n",
-    "| **Total flow time**      |     11    |\n",
-    "| **Total tardiness**      |     3     |\n",
-    "| **Total earliness**      |     2     |\n",
-    "| **Maximum tardiness**    |     3     |\n",
-    "| **Maximum lateness**     |     3     |\n",
-    "| **Total setup time**     |     0     |"
-   ]
+   "source": "We now explain how the objective value is calculated in general. To that end, let $w_j$ denote the weight of job $j$ and let $w_{\\text{obj}}$ denote the weight of objective $\\text{obj}$ (see the previous section for an overview of all objectives). We denote the contribution of job $j$ to the objective $\\text{obj}$ in schedule $s$ as $\\text{contribution}(j, \\text{obj}, s)$. The value of the makespan of schedule $s$ is denoted by $\\text{makespan}(s)$ and the value of the total setup time of schedule $s$ is denoted by $\\text{TST}(s)$. The general objective value for schedule $s$ is calculated in PyJobShop as follows:\n\\begin{equation}\n\\text{objective}(s) = w_{\\text{makespan}} \\cdot \\text{makespan}(s) + w_{\\text{TST}} \\cdot \\text{TST}(s) + \\sum_{\\text{obj} \\neq \\text{makespan}, \\text{TST}} w_{\\text{obj}} \\cdot \\sum_{j} w_j \\cdot \\text{contribution}(j, \\text{obj}, s).\n\\end{equation}\nThe following simple example of two jobs, with given weights, release date, and start and end times, shows how the objective components are calculated and combined in the different objective values. In particular, the following table shows the objective component values for the two jobs.\n\n| **Job** | **Weights** | **Release date** | **Start time** | **End time** | **Due date** | **Tardy? (1=yes, 0=no)** | **Flow time** | **Tardiness** | **Earliness** |\n|:-------:|:-----------:|:----------------:|:--------------:|:------------:|:------------:|:------------------------:|:-------------:|:-------------:|:-------------:|\n|    1    |      3      |         1        |        2       |       4      |       3      |             1            |       3       |       1       |       0       |\n|    2    |      1      |         0        |        0       |       2      |       4      |             0            |       2       |       0       |       2       |\n\nBased on these objective component values, the following table shows the different objective values for the example.\n\n| **Objective**            | **Value** |\n|--------------------------|:---------:|\n| **Makespan**             |     4     |\n| **Number of tardy jobs** |     3     |\n| **Total flow time**      |     11    |\n| **Total tardiness**      |     3     |\n| **Total earliness**      |     2     |\n| **Maximum tardiness**    |     3     |\n| **Total setup time**     |     0     |"
   },
   {
    "cell_type": "markdown",

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -182,7 +182,6 @@ class Model:
             weight_total_flow_time=data.objective.weight_total_flow_time,
             weight_total_earliness=data.objective.weight_total_earliness,
             weight_max_tardiness=data.objective.weight_max_tardiness,
-            weight_max_lateness=data.objective.weight_max_lateness,
             weight_total_setup_time=data.objective.weight_total_setup_time,
         )
 
@@ -456,7 +455,6 @@ class Model:
         weight_total_flow_time: int = 0,
         weight_total_earliness: int = 0,
         weight_max_tardiness: int = 0,
-        weight_max_lateness: int = 0,
         weight_total_setup_time: int = 0,
     ) -> Objective:
         """
@@ -469,7 +467,6 @@ class Model:
             weight_total_flow_time=weight_total_flow_time,
             weight_total_earliness=weight_total_earliness,
             weight_max_tardiness=weight_max_tardiness,
-            weight_max_lateness=weight_max_lateness,
             weight_total_setup_time=weight_total_setup_time,
         )
         return self._objective

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -724,10 +724,6 @@ class Objective:
         .. math::
             U_{\max} = \max_{j \in J} w_j (\max(C_j - d_j, 0))
 
-    **Maximum lateness** (:math:`L_{\max}`): The weighted maximum lateness of all jobs. Lateness can be negative, unlike tardiness.
-        .. math::
-            L_{\max} = \max_{j \in J} w_j (C_j - d_j)
-
     **Total setup time** (:math:`TST`): The sum of all sequence-dependent setup times between consecutive tasks on each machine, where :math:`R` denotes the set of machines, :math:`M^R_r` denotes the set of modes requiring :math:`r \in R`, :math:`s_{t_u, t_v, r}` denotes the setup time between tasks :math:`t_u` and :math:`t_v` on machine :math:`r` and :math:`b_{ruv}` is the binary variable indicating whether task :math:`t_u` is followed by task :math:`t_v` on machine :math:`r`.
         .. math::
             TST = \sum_{r \in R} \sum_{u, v \in M^R_r} s_{t_u, t_v, r} b_{ruv}
@@ -743,7 +739,6 @@ class Objective:
     weight_total_tardiness: int = 0
     weight_total_earliness: int = 0
     weight_max_tardiness: int = 0
-    weight_max_lateness: int = 0
     weight_total_setup_time: int = 0
 
     def __post_init__(self):
@@ -972,7 +967,6 @@ class ProblemData:
             or self.objective.weight_total_tardiness > 0
             or self.objective.weight_total_earliness > 0
             or self.objective.weight_max_tardiness > 0
-            or self.objective.weight_max_lateness > 0
         ):
             if any(job.due_date is None for job in self.jobs):
                 msg = "Job due dates required for due date-based objectives."

--- a/pyjobshop/solvers/cpoptimizer/Objective.py
+++ b/pyjobshop/solvers/cpoptimizer/Objective.py
@@ -85,16 +85,6 @@ class Objective:
         ]
         return cpo.max(tardiness)  # type: ignore
 
-    def _max_lateness_expr(self) -> CpoExpr:
-        """
-        Returns an expression representing the maximum lateness of jobs.
-        """
-        lateness = [
-            job.weight * (cpo.end_of(var) - job.due_date)
-            for job, var in zip(self._data.jobs, self._job_vars)
-        ]
-        return cpo.max(lateness)  # type: ignore
-
     def _total_setup_time_expr(self) -> CpoExpr:
         """
         Returns an expression representing the total setup times.
@@ -140,7 +130,6 @@ class Objective:
             (objective.weight_total_flow_time, self._total_flow_time_expr),
             (objective.weight_total_earliness, self._total_earliness_expr),
             (objective.weight_max_tardiness, self._max_tardiness_expr),
-            (objective.weight_max_lateness, self._max_lateness_expr),
             (objective.weight_total_setup_time, self._total_setup_time_expr),
         ]
         exprs = [weight * expr() for weight, expr in items if weight > 0]

--- a/pyjobshop/solvers/ortools/Objective.py
+++ b/pyjobshop/solvers/ortools/Objective.py
@@ -117,25 +117,6 @@ class Objective:
         model.add_max_equality(max_tardiness, tardiness_vars)
         return max_tardiness
 
-    def _max_lateness_expr(self) -> LinearExprT:
-        """
-        Returns an expression representing the maximum tardiness of jobs.
-        """
-        model, data = self._model, self._data
-        lateness_vars = []
-
-        for job, var in zip(data.jobs, self._variables.job_vars):
-            assert job.due_date is not None
-            lateness = model.new_int_var(
-                -MAX_VALUE, MAX_VALUE, f"lateness_{job}"
-            )
-            model.add(lateness == var.end - job.due_date)
-            lateness_vars.append(job.weight * lateness)
-
-        max_lateness = model.new_int_var(-MAX_VALUE, MAX_VALUE, "max_lateness")
-        model.add_max_equality(max_lateness, lateness_vars)
-        return max_lateness
-
     def _total_setup_time_expr(self) -> LinearExprT:
         """
         Returns an expression representing the total setup time of tasks.
@@ -177,7 +158,6 @@ class Objective:
             (objective.weight_total_flow_time, self._total_flow_time_expr),
             (objective.weight_total_earliness, self._total_earliness_expr),
             (objective.weight_max_tardiness, self._max_tardiness_expr),
-            (objective.weight_max_lateness, self._max_lateness_expr),
             (objective.weight_total_setup_time, self._total_setup_time_expr),
         ]
         exprs = [weight * expr() for weight, expr in items if weight > 0]

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -110,7 +110,6 @@ def test_from_data():
             weight_total_flow_time=5,
             weight_total_earliness=6,
             weight_max_tardiness=7,
-            weight_max_lateness=8,
         ),
     )
     model = Model.from_data(data)
@@ -315,8 +314,7 @@ def test_model_set_objective():
         weight_total_flow_time=4,
         weight_total_earliness=5,
         weight_max_tardiness=6,
-        weight_max_lateness=7,
-        weight_total_setup_time=8,
+        weight_total_setup_time=7,
     )
 
     assert_equal(model.objective.weight_makespan, 1)
@@ -325,8 +323,7 @@ def test_model_set_objective():
     assert_equal(model.objective.weight_total_flow_time, 4)
     assert_equal(model.objective.weight_total_earliness, 5)
     assert_equal(model.objective.weight_max_tardiness, 6)
-    assert_equal(model.objective.weight_max_lateness, 7)
-    assert_equal(model.objective.weight_total_setup_time, 8)
+    assert_equal(model.objective.weight_total_setup_time, 7)
 
 
 def test_solve(solver: str):

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -343,14 +343,13 @@ def test_constraints_str():
 @pytest.mark.parametrize(
     "weights",
     [
-        [-1, 0, 0, 0, 0, 0, 0, 0],  # weight_makespan < 0,
-        [0, -1, 0, 0, 0, 0, 0, 0],  # weight_tardy_jobs < 0
-        [0, 0, -1, 0, 0, 0, 0, 0],  # weight_total_flow_time < 0
-        [0, 0, 0, -1, 0, 0, 0, 0],  # weight_total_tardiness < 0
-        [0, 0, 0, 0, -1, 0, 0, 0],  # weight_total_earliness < 0
-        [0, 0, 0, 0, 0, -1, 0, 0],  # weight_max_tardiness < 0
-        [0, 0, 0, 0, 0, 0, -1, 0],  # weight_max_lateness < 0
-        [0, 0, 0, 0, 0, 0, 0, -1],  # weight_total_setup_time < 0
+        [-1, 0, 0, 0, 0, 0, 0],  # weight_makespan < 0,
+        [0, -1, 0, 0, 0, 0, 0],  # weight_tardy_jobs < 0
+        [0, 0, -1, 0, 0, 0, 0],  # weight_total_flow_time < 0
+        [0, 0, 0, -1, 0, 0, 0],  # weight_total_tardiness < 0
+        [0, 0, 0, 0, -1, 0, 0],  # weight_total_earliness < 0
+        [0, 0, 0, 0, 0, -1, 0],  # weight_max_tardiness < 0
+        [0, 0, 0, 0, 0, 0, -1],  # weight_total_setup_time < 0
     ],
 )
 def test_objective_valid_values(weights: list[int]):
@@ -685,7 +684,6 @@ def test_problem_data_raises_mode_dependency_same_task():
         Objective(weight_total_tardiness=1),
         Objective(weight_total_earliness=1),
         Objective(weight_max_tardiness=1),
-        Objective(weight_max_lateness=1),
     ],
 )
 def test_problem_data_tardy_objective_without_job_due_dates(
@@ -1795,31 +1793,6 @@ def test_max_tardiness(solver: str):
     # has weight 1. So the maximum tardiness is 2 * 2 = 4. Multiplied with the
     # ``weight_max_tardiness`` of 2, the objective value is 8.
     assert_equal(result.objective, 8)
-    assert_equal(result.best.tasks[0].end, 2)
-    assert_equal(result.best.tasks[1].end, 2)
-
-
-def test_max_lateness(solver: str):
-    """
-    Tests that the maximum lateness objective function is correctly optimized.
-    Specifically, we also check that lateness can be negative.
-    """
-    model = Model()
-
-    for idx in range(2):
-        machine = model.add_machine()
-        job = model.add_job(weight=idx + 1, due_date=4)
-        task = model.add_task(job=job)
-        model.add_mode(task, machine, duration=2)
-
-    model.set_objective(weight_max_lateness=2)
-
-    result = model.solve(solver=solver)
-
-    # Both jobs are "late" by -2 time units, but job 1 has weight 2 and job 2
-    # has weight 1. So the maximum lateness is -2 * 1 = -2. Multiplied with the
-    # ``weight_max_lateness`` of 2, the objective value is -4.
-    assert_equal(result.objective, -4)
     assert_equal(result.best.tasks[0].end, 2)
     assert_equal(result.best.tasks[1].end, 2)
 


### PR DESCRIPTION
This PR removes the maximum lateness. Unlike all other objectives, maximum lateness can take on negative values. This has some annoying interactions with #269 for example. I think it's easiest to only consider objectives that can be strictly non-negative.

- [ ] Closes #xxxx.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyjobshop.org/latest/dev/contributing.html) first.
In particular:

- You must add tests when making code changes. This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyJobShop's MIT license. Please check that this PR can be included into PyJobShop under the MIT license.

</details>
