### PR TITLE
Lower `MAX_VALUE` constant

### DIFF
--- a/pyjobshop/constants.py
+++ b/pyjobshop/constants.py
@@ -1,3 +1,3 @@
-MAX_VALUE = 2**44
-"""int: Maximum allowed value, equal to 2^48.
+MAX_VALUE = 2**42
+"""int: Maximum allowed value, equal to 2^42.
 """


### PR DESCRIPTION
This PR lowers MAX_VALUE to `2**42`. This makes it possible to run the following program, which is pretty much the limit of what OR-Tools can handle on my M3 Pro:

```python
from pyjobshop import Model

model = Model()
machine = model.add_machine()

for idx in range(100000):
    job = model.add_job()
    task = model.add_task(job, name=f"task_{idx}")
    mode = model.add_mode(task, machine, duration=1)

result = model.solve()
```

<details>

**Notes**:

Please read our [contributing guidelines](https://pyjobshop.org/latest/dev/contributing.html) first.
In particular:

- You must add tests when making code changes. This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyJobShop's MIT license. Please check that this PR can be included into PyJobShop under the MIT license.

</details>
