### PR TITLE
Add before sequencing constraint

### DIFF
--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from pyjobshop.constants import MAX_VALUE
 from pyjobshop.ProblemData import (
+    Before,
     Break,
     Consecutive,
     Constraints,
@@ -384,6 +385,18 @@ class Model:
 
         return constraint
 
+    def add_before(self, task1: Task, task2: Task) -> Before:
+        """
+        Adds a constraint that the first task must be scheduled before the
+        second task on machines that they are both scheduled on. Unlike
+        ``add_consecutive``, other tasks may appear between them.
+        """
+        idx1, idx2 = self._id2task[id(task1)], self._id2task[id(task2)]
+        constraint = Before(idx1, idx2)
+        self._constraints.before.append(constraint)
+
+        return constraint
+
     def add_same_sequence(
         self,
         machine1: Machine,
@@ -602,6 +615,9 @@ class Model:
 
         for idx1, idx2 in data.constraints.consecutive:
             model.add_consecutive(tasks[idx1], tasks[idx2])
+
+        for idx1, idx2 in data.constraints.before:
+            model.add_before(tasks[idx1], tasks[idx2])
 
         for idcs in data.constraints.same_sequence:
             res_idx1, res_idx2, task_idcs1, task_idcs2 = idcs

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -472,6 +472,27 @@ class Consecutive(IterableMixin):
 
 
 @dataclass
+class Before(IterableMixin):
+    """
+    Sequence task 1 before task 2 on the machines they are both assigned to.
+    Unlike ``Consecutive``, other tasks may appear between them.
+
+    Hand-waving some details, let :math:`m_1, m_2` be the selected modes of
+    task 1 and task 2, and let :math:`R` denote the machines that both modes
+    require. This constraint ensures that
+
+    .. math::
+        m_1 \\prec m_2 \\quad \\forall r \\in R,
+
+    where :math:`\\prec` means that :math:`m_1` is ordered before
+    :math:`m_2` in the sequence (but not necessarily directly before).
+    """
+
+    task1: int
+    task2: int
+
+
+@dataclass
 class SameSequence(IterableMixin):
     """
     Ensures that two machines process their assigned tasks in the same relative
@@ -625,6 +646,7 @@ class Constraints:
     identical_resources: list[IdenticalResources] = field(default_factory=list)
     different_resources: list[DifferentResources] = field(default_factory=list)
     consecutive: list[Consecutive] = field(default_factory=list)
+    before: list[Before] = field(default_factory=list)
     same_sequence: list[SameSequence] = field(default_factory=list)
     setup_times: list[SetupTime] = field(default_factory=list)
     mode_dependencies: list[ModeDependency] = field(default_factory=list)
@@ -888,6 +910,7 @@ class ProblemData:
             (self.constraints.identical_resources, "identical_resources"),
             (self.constraints.different_resources, "different_resources"),
             (self.constraints.consecutive, "consecutive"),
+            (self.constraints.before, "before"),
         ]
 
         for constraints, name in task_pair_constraints:

--- a/pyjobshop/__init__.py
+++ b/pyjobshop/__init__.py
@@ -1,5 +1,6 @@
 from .constants import MAX_VALUE as MAX_VALUE
 from .Model import Model as Model
+from .ProblemData import Before as Before
 from .ProblemData import Consecutive as Consecutive
 from .ProblemData import Constraints as Constraints
 from .ProblemData import Consumable as Consumable

--- a/pyjobshop/solvers/cpoptimizer/Constraints.py
+++ b/pyjobshop/solvers/cpoptimizer/Constraints.py
@@ -277,6 +277,25 @@ class Constraints:
 
                     model.add(cpo.previous(seq_var, var1, var2))
 
+    def _before_constraints(self):
+        """
+        Creates the before constraints.
+        """
+        model, data, variables = self._model, self._data, self._variables
+
+        for idx1, idx2 in data.constraints.before:
+            intersecting = utils.intersecting_modes(data, idx1, idx2)
+
+            for mode1, mode2, resources in intersecting:
+                res_idcs = set(resources) & set(data.machine_idcs)
+
+                for res_idx in res_idcs:
+                    seq_var = variables.sequence_vars[res_idx]
+                    var1 = variables.mode_vars[mode1]
+                    var2 = variables.mode_vars[mode2]
+
+                    model.add(cpo.before(seq_var, var1, var2))
+
     def _same_sequence_constraints(self):
         """
         Creates the same sequence constraints.
@@ -385,6 +404,7 @@ class Constraints:
         self._timing_constraints()
         self._identical_and_different_resource_constraints()
         self._consecutive_constraints()
+        self._before_constraints()
         self._same_sequence_constraints()
         self._mode_dependencies()
         self._task_selection_constraints()

--- a/pyjobshop/solvers/ortools/Constraints.py
+++ b/pyjobshop/solvers/ortools/Constraints.py
@@ -247,6 +247,29 @@ class Constraints:
 
                 model.add(arc == 1).only_enforce_if(both_present)
 
+    def _before_constraints(self):
+        """
+        Creates the before constraints. Task 1 must appear before task 2
+        in the sequence, but other tasks may appear between them.
+        """
+        model, data, variables = self._model, self._data, self._variables
+
+        for task_idx1, task_idx2 in data.constraints.before:
+            for res_idx in data.machine_idcs:
+                var1 = variables.assign_vars.get((task_idx1, res_idx))
+                var2 = variables.assign_vars.get((task_idx2, res_idx))
+                if not (var1 and var2):
+                    continue
+
+                seq_var = variables.sequence_vars[res_idx]
+                seq_var.activate_ranks(model)
+
+                rank1 = seq_var.ranks[task_idx1]
+                rank2 = seq_var.ranks[task_idx2]
+                both_present = [var1.present, var2.present]
+
+                model.add(rank1 < rank2).only_enforce_if(both_present)
+
     def _same_sequence_constraints(self):
         """
         Creates the same sequence constraints.
@@ -344,6 +367,28 @@ class Constraints:
 
                     model.add(expr).only_enforce_if(arc)
 
+            if not seq_var.ranks:
+                continue
+
+            ranks = seq_var.ranks
+
+            for task_idx in res_tasks:
+                var = variables.assign_vars[task_idx, res_idx]
+                model.add(ranks[task_idx] == -1).only_enforce_if(~var.present)
+
+                start_arc = arcs[seq_var.DUMMY, task_idx]
+                model.add(ranks[task_idx] == 0).only_enforce_if(start_arc)
+
+            for task_idx1 in res_tasks:
+                for task_idx2 in res_tasks:
+                    if task_idx1 == task_idx2:
+                        continue
+
+                    arc = arcs[task_idx1, task_idx2]
+                    model.add(
+                        ranks[task_idx2] == ranks[task_idx1] + 1
+                    ).only_enforce_if(arc)
+
     def _mode_dependencies(self):
         """
         Implements the mode dependency constraints.
@@ -404,6 +449,7 @@ class Constraints:
         self._timing_constraints()
         self._identical_and_different_resource_constraints()
         self._consecutive_constraints()
+        self._before_constraints()
         self._same_sequence_constraints()
         self._circuit_constraints()  # must be after sequencing constraints!
         self._mode_dependencies()

--- a/pyjobshop/solvers/ortools/Variables.py
+++ b/pyjobshop/solvers/ortools/Variables.py
@@ -169,6 +169,7 @@ class SequenceVar:
     def __init__(self, tasks: list[int]):
         self._tasks = tasks
         self._arcs: dict[tuple[TaskIdx, TaskIdx], BoolVarT] = {}
+        self._ranks: dict[int, IntVar] = {}
         self._is_active = False
 
     @property
@@ -179,11 +180,35 @@ class SequenceVar:
         return self._arcs
 
     @property
+    def ranks(self) -> dict[int, IntVar]:
+        """
+        Returns the rank variables of the sequence variable.
+        """
+        return self._ranks
+
+    @property
     def is_active(self) -> bool:
         """
         Returns whether the sequence variable is active.
         """
         return self._is_active
+
+    def activate_ranks(self, model: CpModel):
+        """
+        Activates rank variables for all tasks in this sequence. Rank
+        variables track the position of each task in the sequence, which
+        is needed for before constraints.
+        """
+        if self._ranks:
+            return
+
+        self.activate(model)
+
+        num_tasks = len(self._tasks)
+        self._ranks = {
+            task: model.new_int_var(-1, num_tasks - 1, f"rank_{task}")
+            for task in self._tasks
+        }
 
     def activate(self, model: CpModel):
         """

--- a/pyjobshop/solvers/ortools/Variables.py
+++ b/pyjobshop/solvers/ortools/Variables.py
@@ -813,3 +813,14 @@ class Variables:
                     )
 
                 model.add_hint(arc, hint)
+
+            if not seq_var.ranks:
+                continue
+
+            # Sort assigned tasks by start time to determine ranks.
+            sorted_tasks = sorted(assigned, key=task_start)
+            task2rank = {task: rank for rank, task in enumerate(sorted_tasks)}
+
+            for task_idx, rank_var in seq_var.ranks.items():
+                rank = task2rank.get(task_idx, -1)
+                model.add_hint(rank_var, rank)

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -2,6 +2,7 @@ from numpy.testing import assert_equal
 
 from pyjobshop.Model import Model
 from pyjobshop.ProblemData import (
+    Before,
     Consecutive,
     Constraints,
     DifferentResources,
@@ -42,6 +43,7 @@ def test_model_to_data():
     model.add_identical_resources(task2, task1)
     model.add_different_resources(task2, task1)
     model.add_consecutive(task2, task1)
+    model.add_before(task2, task1)
     model.add_same_sequence(machine1, machine2, [task1], [task2])
     model.add_setup_time(machine1, task1, task2, 3)
     model.add_setup_time(machine2, task1, task2, 4)
@@ -73,6 +75,7 @@ def test_model_to_data():
         identical_resources=[IdenticalResources(1, 0)],
         different_resources=[DifferentResources(1, 0)],
         consecutive=[Consecutive(1, 0)],
+        before=[Before(1, 0)],
         same_sequence=[SameSequence(0, 1, [0], [1])],
         setup_times=[SetupTime(0, 0, 1, 3), SetupTime(1, 0, 1, 4)],
         mode_dependencies=[ModeDependency(0, [1])],

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -2077,6 +2077,9 @@ def test_before_constraint_different_machines(solver: str):
 
     result = model.solve(solver=solver)
 
+    # The solver assigns the tasks to different machines, so they run in
+    # parallel and the before constraint is a no-op. Makespan = max(5, 1) = 5.
+    # If the constraint forced sequential execution, it would be 5 + 1 = 6.
     assert_equal(result.objective, 5)
     assert_equal(result.status.value, "Optimal")
 

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -2083,6 +2083,39 @@ def test_before_constraint_different_machines(solver: str):
     assert_equal(result.status.value, "Optimal")
 
 
+def test_before_constraint_chain(solver: str):
+    """
+    Tests that chained before constraints are respected.
+    """
+    model = Model()
+
+    machine = model.add_machine()
+    task1 = model.add_task()
+    task2 = model.add_task()
+    task3 = model.add_task()
+
+    model.add_mode(task1, machine, duration=1)
+    model.add_mode(task2, machine, duration=1)
+    model.add_mode(task3, machine, duration=1)
+
+    # before(task1, task2) + before(task2, task3) transitively forces
+    # task1 before task3.
+    model.add_before(task1, task2)
+    model.add_before(task2, task3)
+
+    # Large setup time from task1 to task3 to incentivize the solver to
+    # put task1 after task3 if it could.
+    model.add_setup_time(machine, task1, task3, duration=100)
+
+    result = model.solve(solver=solver)
+
+    # The only feasible ordering is task1 -> task2 -> task3 with
+    # makespan = 1 + 0 + 1 + 0 + 1 = 3. The setup time from task1 to
+    # task3 does not apply since they are not directly adjacent.
+    assert_equal(result.objective, 3)
+    assert_equal(result.status.value, "Optimal")
+
+
 def test_consecutive_multiple_machines(solver: str):
     """
     Test the consecutive constraint with tasks that have modes with multiple

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -2079,7 +2079,6 @@ def test_before_constraint_different_machines(solver: str):
 
     # The solver assigns the tasks to different machines, so they run in
     # parallel and the before constraint is a no-op. Makespan = max(5, 1) = 5.
-    # If the constraint forced sequential execution, it would be 5 + 1 = 6.
     assert_equal(result.objective, 5)
     assert_equal(result.status.value, "Optimal")
 

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -2066,10 +2066,13 @@ def test_before_constraint_different_machines(solver: str):
     task2 = model.add_task()
 
     model.add_mode(task1, machine1, duration=5)
+    model.add_mode(task1, machine2, duration=5)
+    model.add_mode(task2, machine1, duration=1)
     model.add_mode(task2, machine2, duration=1)
 
-    # Before constraint should have no effect since the tasks do not
-    # share a machine. Task 2 can start at time 0 in parallel.
+    # Before constraint should have no effect when the tasks are assigned
+    # to different machines. The solver assigns them to separate machines
+    # so they run in parallel.
     model.add_before(task1, task2)
 
     result = model.solve(solver=solver)

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -2053,6 +2053,31 @@ def test_before_constraint(solver: str):
     assert_equal(result.status.value, "Optimal")
 
 
+def test_before_constraint_different_machines(solver: str):
+    """
+    Tests that the before constraint is a no-op when tasks are on different
+    machines.
+    """
+    model = Model()
+
+    machine1 = model.add_machine()
+    machine2 = model.add_machine()
+    task1 = model.add_task()
+    task2 = model.add_task()
+
+    model.add_mode(task1, machine1, duration=5)
+    model.add_mode(task2, machine2, duration=1)
+
+    # Before constraint should have no effect since the tasks do not
+    # share a machine. Task 2 can start at time 0 in parallel.
+    model.add_before(task1, task2)
+
+    result = model.solve(solver=solver)
+
+    assert_equal(result.objective, 5)
+    assert_equal(result.status.value, "Optimal")
+
+
 def test_consecutive_multiple_machines(solver: str):
     """
     Test the consecutive constraint with tasks that have modes with multiple

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_, assert_equal, assert_raises
 from pyjobshop.constants import MAX_VALUE
 from pyjobshop.Model import Model
 from pyjobshop.ProblemData import (
+    Before,
     Consecutive,
     Constraints,
     Consumable,
@@ -364,6 +365,7 @@ def test_constraints_len():
         identical_resources=[IdenticalResources(0, 1)],
         different_resources=[DifferentResources(0, 1)],
         consecutive=[Consecutive(1, 2)],
+        before=[Before(1, 2)],
         same_sequence=[SameSequence(0, 1)],
         setup_times=[
             SetupTime(0, 0, 1, 1),  # machine
@@ -376,7 +378,7 @@ def test_constraints_len():
         select_exactly_one=[SelectAtLeastOne([1, 0])],
     )
 
-    assert_equal(len(constraints), 15)
+    assert_equal(len(constraints), 16)
 
 
 def test_constraints_str():
@@ -678,6 +680,7 @@ def test_problem_data_all_modes_demand_infeasible():
         ("identical_resources", IdenticalResources, [(2, 0), (0, 2)]),
         ("different_resources", DifferentResources, [(2, 0), (0, 2)]),
         ("consecutive", Consecutive, [(2, 0), (0, 2)]),
+        ("before", Before, [(2, 0), (0, 2)]),
         (
             "same_sequence",
             SameSequence,
@@ -2018,6 +2021,36 @@ def test_consecutive_constraint(solver: str):
     # Task 2 must be scheduled directly before task 1, but the setup time
     # between them is 100, so the makespan is 1 + 100 + 1 = 102.
     assert_equal(result.objective, 102)
+
+
+def test_before_constraint(solver: str):
+    """
+    Tests that the before constraint is respected but allows gaps.
+    """
+    model = Model()
+
+    machine = model.add_machine()
+    task1 = model.add_task()
+    task2 = model.add_task()
+    task3 = model.add_task()
+
+    model.add_mode(task1, machine, duration=1)
+    model.add_mode(task2, machine, duration=1)
+    model.add_mode(task3, machine, duration=2)
+
+    # task1 must come before task2, but task3 can be between them.
+    model.add_before(task1, task2)
+
+    # Add a large setup time from task1 directly to task2, so the solver
+    # is incentivized to put task3 between them.
+    model.add_setup_time(machine, task1, task2, duration=100)
+
+    result = model.solve(solver=solver)
+
+    # Optimal: task1 -> task3 -> task2, makespan = 1 + 0 + 2 + 0 + 1 = 4
+    # If before were consecutive, makespan would be 1 + 100 + 1 = 102.
+    assert_equal(result.objective, 4)
+    assert_equal(result.status.value, "Optimal")
 
 
 def test_consecutive_multiple_machines(solver: str):

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -2083,36 +2083,29 @@ def test_before_constraint_different_machines(solver: str):
     assert_equal(result.status.value, "Optimal")
 
 
-def test_before_constraint_chain(solver: str):
+def test_before_constraint_optional_task(solver: str):
     """
-    Tests that chained before constraints are respected.
+    Tests that the before constraint is vacuously satisfied when one of
+    the tasks is optional and absent from the solution.
     """
     model = Model()
 
     machine = model.add_machine()
-    task1 = model.add_task()
+    task1 = model.add_task(optional=True)
     task2 = model.add_task()
-    task3 = model.add_task()
 
     model.add_mode(task1, machine, duration=1)
     model.add_mode(task2, machine, duration=1)
-    model.add_mode(task3, machine, duration=1)
 
-    # before(task1, task2) + before(task2, task3) transitively forces
-    # task1 before task3.
-    model.add_before(task1, task2)
-    model.add_before(task2, task3)
-
-    # Large setup time from task1 to task3 to incentivize the solver to
-    # put task1 after task3 if it could.
-    model.add_setup_time(machine, task1, task3, duration=100)
+    # A before constraint in the "wrong" direction. If task1 were present,
+    # the setup time from task2 to task1 would force a makespan of 102.
+    # Since task1 is optional, the solver drops it and the makespan is 1.
+    model.add_before(task2, task1)
+    model.add_setup_time(machine, task2, task1, duration=100)
 
     result = model.solve(solver=solver)
 
-    # The only feasible ordering is task1 -> task2 -> task3 with
-    # makespan = 1 + 0 + 1 + 0 + 1 = 3. The setup time from task1 to
-    # task3 does not apply since they are not directly adjacent.
-    assert_equal(result.objective, 3)
+    assert_equal(result.objective, 1)
     assert_equal(result.status.value, "Optimal")
 
 


### PR DESCRIPTION
## Summary

- Closes #430.
- Adds a `Before` sequencing constraint that ensures task 1 is ordered before task 2 on shared machines, but unlike `Consecutive`, allows other tasks between them.
- For OR-Tools CP-SAT, introduces rank variables on `SequenceVar` that track task positions in the sequence, linked to arc variables via the circuit constraint.
- For CP Optimizer, uses the native `cpo.before()` constraint.