### PR TITLE
Add maximum earliness objective (weight_max_earliness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It currently supports the following scheduling problems:
 
 - **Resource environments:** single machines, parallel machines, hybrid flow shops, open shops, job shops, flexible job shops, distributed shops, renewable resources and consumable resources.
 - **Constraints:** release dates, deadlines, due dates, multiple modes, permutations, sequence-dependent setup times, no-wait, blocking, breaks, optional task selection, and arbitrary precedence constraints.
-- **Objective functions:** minimizing makespan, total flow time, number of tardy jobs, total tardiness, total earliness, maximum tardiness, and total setup times.
+- **Objective functions:** minimizing makespan, total flow time, number of tardy jobs, total tardiness, total earliness, maximum tardiness, maximum earliness, and total setup times.
 
 You can find PyJobShop on the Python Package Index under the name `pyjobshop`.
 To install it, simply run:

--- a/conftest.py
+++ b/conftest.py
@@ -104,6 +104,7 @@ def complete_data():
         weight_total_earliness=6,
         weight_max_tardiness=7,
         weight_total_setup_time=8,
+        weight_max_earliness=9,
     )
     return ProblemData(
         jobs,

--- a/examples/objectives.ipynb
+++ b/examples/objectives.ipynb
@@ -301,6 +301,7 @@
     "- **Total tardiness:** the weighted sum of the tardiness of each job, where the tardiness of a job is the difference between its completion time and its due date, where tardiness is 0 when it is completed before its due date.\n",
     "- **Total earliness:** the weighted sum of the earliness of each job, where the earliness of a job is the difference between its due date and its completion time, where earliness is 0 when its completion time is after its due date.\n",
     "- **Maximum tardiness:** the maximum weighted tardiness of all jobs.\n",
+    "- **Maximum earliness:** the maximum weighted earliness of all jobs.\n",
     "- **Total setup time:** the sum of all sequence-dependent setup times between consecutive tasks on each machine.\n",
     "\n",
     "The objective weights are captured in the `Objective` class; for more details, see its [API documentation](https://pyjobshop.org/stable/api/pyjobshop.html#pyjobshop.ProblemData.Objective)."
@@ -319,7 +320,7 @@
    "source": [
     "We now explain how the objective value is calculated in general. To that end, let $w_j$ denote the weight of job $j$ and let $w_{\\text{obj}}$ denote the weight of objective $\\text{obj}$ (see the previous section for an overview of all objectives). We denote the contribution of job $j$ to the objective $\\text{obj}$ in schedule $s$ as $\\text{contribution}(j, \\text{obj}, s)$. The value of the makespan of schedule $s$ is denoted by $\\text{makespan}(s)$ and the value of the total setup time of schedule $s$ is denoted by $\\text{TST}(s)$. The general objective value for schedule $s$ is calculated in PyJobShop as follows:\n",
     "\\begin{equation}\n",
-    "\\text{objective}(s) = w_{\\text{makespan}} \\cdot \\text{makespan}(s) + w_{\\text{TST}} \\cdot \\text{TST}(s) + w_{\\text{max tard.}} \\cdot \\max_{j} \\left( w_j \\cdot \\text{tardiness}(j, s) \\right) + \\sum_{\\text{obj} \\neq \\text{makespan}, \\text{TST}, \\text{max tard.}} w_{\\text{obj}} \\cdot \\sum_{j} w_j \\cdot \\text{contribution}(j, \\text{obj}, s).\n",
+    "\\text{objective}(s) = w_{\\text{makespan}} \\cdot \\text{makespan}(s) + w_{\\text{TST}} \\cdot \\text{TST}(s) + w_{\\text{max tard.}} \\cdot \\max_{j} \\left( w_j \\cdot \\text{tardiness}(j, s) \\right) + w_{\\text{max early.}} \\cdot \\max_{j} \\left( w_j \\cdot \\text{earliness}(j, s) \\right) + \\sum_{\\text{obj} \\neq \\text{makespan}, \\text{TST}, \\text{max tard.}, \\text{max early.}} w_{\\text{obj}} \\cdot \\sum_{j} w_j \\cdot \\text{contribution}(j, \\text{obj}, s).\n",
     "\\end{equation}\n",
     "The following simple example of two jobs, with given weights, release date, and start and end times, shows how the objective components are calculated and combined in the different objective values. In particular, the following table shows the objective component values for the two jobs.\n",
     "\n",
@@ -338,6 +339,7 @@
     "| **Total tardiness**      |     3     |\n",
     "| **Total earliness**      |     2     |\n",
     "| **Maximum tardiness**    |     3     |\n",
+    "| **Maximum earliness**    |     2     |\n",
     "| **Total setup time**     |     0     |"
    ]
   },

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -496,6 +496,7 @@ class Model:
         weight_total_earliness: int = 0,
         weight_max_tardiness: int = 0,
         weight_total_setup_time: int = 0,
+        weight_max_earliness: int = 0,
     ) -> Objective:
         """
         Sets the objective function in this model.
@@ -508,6 +509,7 @@ class Model:
             weight_total_earliness=weight_total_earliness,
             weight_max_tardiness=weight_max_tardiness,
             weight_total_setup_time=weight_total_setup_time,
+            weight_max_earliness=weight_max_earliness,
         )
         return self._objective
 
@@ -646,6 +648,7 @@ class Model:
             weight_total_earliness=data.objective.weight_total_earliness,
             weight_max_tardiness=data.objective.weight_max_tardiness,
             weight_total_setup_time=data.objective.weight_total_setup_time,
+            weight_max_earliness=data.objective.weight_max_earliness,
         )
 
         return model

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -676,6 +676,10 @@ class Objective:
         .. math::
             U_{\max} = \max_{j \in J} w_j (\max(C_j - d_j, 0))
 
+    **Maximum earliness** (:math:`E_{\max}`): The weighted maximum earliness of all jobs.
+        .. math::
+            E_{\max} = \max_{j \in J} w_j (\max(d_j - C_j, 0))
+
     **Total setup time** (:math:`TST`): The sum of all sequence-dependent setup times between consecutive tasks on each machine, where :math:`R` denotes the set of machines, :math:`M^R_r` denotes the set of modes requiring :math:`r \in R`, :math:`s_{t_u, t_v, r}` denotes the setup time between tasks :math:`t_u` and :math:`t_v` on machine :math:`r` and :math:`b_{ruv}` is the binary variable indicating whether task :math:`t_u` is followed by task :math:`t_v` on machine :math:`r`.
         .. math::
             TST = \sum_{r \in R} \sum_{u, v \in M^R_r} s_{t_u, t_v, r} b_{ruv}
@@ -692,6 +696,7 @@ class Objective:
     weight_total_earliness: int = 0
     weight_max_tardiness: int = 0
     weight_total_setup_time: int = 0
+    weight_max_earliness: int = 0
 
     def __post_init__(self):
         for f in fields(self):
@@ -997,6 +1002,7 @@ class ProblemData:
             or self.objective.weight_total_tardiness > 0
             or self.objective.weight_total_earliness > 0
             or self.objective.weight_max_tardiness > 0
+            or self.objective.weight_max_earliness > 0
         ) and any(job.due_date is None for job in self.jobs):
             msg = "Job due dates required for due date-based objectives."
             raise ValueError(msg)

--- a/pyjobshop/Solution.py
+++ b/pyjobshop/Solution.py
@@ -212,6 +212,7 @@ class Solution:
             + objective.weight_total_earliness * self.total_earliness
             + objective.weight_max_tardiness * self.max_tardiness
             + objective.weight_total_setup_time * self.total_setup_time
+            + objective.weight_max_earliness * self.max_earliness
         )
 
     @property
@@ -271,6 +272,19 @@ class Solution:
 
         return max(
             self._data.jobs[idx].weight * job.tardiness
+            for idx, job in enumerate(self._jobs)
+        )
+
+    @property
+    def max_earliness(self) -> int:
+        """
+        Returns the maximum earliness of all jobs.
+        """
+        if not self._jobs:
+            return 0
+
+        return max(
+            self._data.jobs[idx].weight * job.earliness
             for idx, job in enumerate(self._jobs)
         )
 

--- a/pyjobshop/solvers/cpoptimizer/Objective.py
+++ b/pyjobshop/solvers/cpoptimizer/Objective.py
@@ -85,6 +85,16 @@ class Objective:
         ]
         return cpo.max(tardiness)  # type: ignore
 
+    def _max_earliness_expr(self) -> CpoExpr:
+        """
+        Returns an expression representing the maximum earliness of jobs.
+        """
+        earliness = [
+            job.weight * cpo.max(0, job.due_date - cpo.end_of(var))
+            for job, var in zip(self._data.jobs, self._job_vars)
+        ]
+        return cpo.max(earliness)  # type: ignore
+
     def _total_setup_time_expr(self) -> CpoExpr:
         """
         Returns an expression representing the total setup times.
@@ -133,6 +143,7 @@ class Objective:
             (objective.weight_total_flow_time, self._total_flow_time_expr),
             (objective.weight_total_earliness, self._total_earliness_expr),
             (objective.weight_max_tardiness, self._max_tardiness_expr),
+            (objective.weight_max_earliness, self._max_earliness_expr),
             (objective.weight_total_setup_time, self._total_setup_time_expr),
         ]
         exprs = [weight * expr() for weight, expr in items if weight > 0]

--- a/pyjobshop/solvers/ortools/Objective.py
+++ b/pyjobshop/solvers/ortools/Objective.py
@@ -55,6 +55,9 @@ class Objective:
         if (obj_weight := objective.weight_max_tardiness) > 0:
             expr += obj_weight * variables.max_tardiness_var
 
+        if (obj_weight := objective.weight_max_earliness) > 0:
+            expr += obj_weight * variables.max_earliness_var
+
         if (obj_weight := objective.weight_total_setup_time) > 0:
             data = self._data
             setup_times = utils.setup_times_matrix(data)

--- a/pyjobshop/solvers/ortools/Variables.py
+++ b/pyjobshop/solvers/ortools/Variables.py
@@ -268,6 +268,7 @@ class Variables:
         self._tardiness_vars: list[IntVar] | None = None
         self._earliness_vars: list[IntVar] | None = None
         self._max_tardiness_var: IntVar | None = None
+        self._max_earliness_var: IntVar | None = None
 
     @property
     def job_vars(self) -> list[JobVar]:
@@ -392,6 +393,18 @@ class Variables:
 
         self._max_tardiness_var = self._make_max_tardiness_variable()
         return self._max_tardiness_var
+
+    @property
+    def max_earliness_var(self) -> IntVar:
+        """
+        Returns the maximum earliness variable, creating it if it does not
+        exist.
+        """
+        if self._max_earliness_var is not None:
+            return self._max_earliness_var
+
+        self._max_earliness_var = self._make_max_earliness_variable()
+        return self._max_earliness_var
 
     def res2assign(self, idx: int) -> list[OptionalIntervalVar]:
         """
@@ -663,6 +676,23 @@ class Variables:
 
         return max_tardiness_var
 
+    def _make_max_earliness_variable(self) -> IntVar:
+        """
+        Creates the maximum earliness variable.
+        """
+        model = self._model
+        max_earliness_var = model.new_int_var(0, MAX_VALUE, "max_earliness")
+
+        if self._job_vars:
+            # Need at least one job to enforce this constraint.
+            earliness_vars = [
+                job.weight * var
+                for job, var in zip(self._data.jobs, self.earliness_vars)
+            ]
+            model.add_max_equality(max_earliness_var, earliness_vars)
+
+        return max_earliness_var
+
     def warmstart(self, solution: Solution):
         """
         Warmstarts the variables based on the given solution.
@@ -705,6 +735,13 @@ class Variables:
                 for idx, job in enumerate(solution.jobs)
             )
             model.add_hint(self.max_tardiness_var, max_tardiness)
+
+        if data.objective.weight_max_earliness > 0:
+            max_earliness = max(
+                data.jobs[idx].weight * job.earliness
+                for idx, job in enumerate(solution.jobs)
+            )
+            model.add_hint(self.max_earliness_var, max_earliness)
 
         if data.objective.weight_makespan > 0:
             model.add_hint(self.makespan_var, solution.makespan)

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -299,6 +299,7 @@ def test_model_set_objective():
         weight_total_earliness=5,
         weight_max_tardiness=6,
         weight_total_setup_time=7,
+        weight_max_earliness=8,
     )
 
     assert_equal(model.objective.weight_makespan, 1)
@@ -308,6 +309,7 @@ def test_model_set_objective():
     assert_equal(model.objective.weight_total_earliness, 5)
     assert_equal(model.objective.weight_max_tardiness, 6)
     assert_equal(model.objective.weight_total_setup_time, 7)
+    assert_equal(model.objective.weight_max_earliness, 8)
 
 
 def test_summary():

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -401,7 +401,8 @@ def test_constraints_str():
         [0, 0, 0, -1, 0, 0, 0],  # weight_total_tardiness < 0
         [0, 0, 0, 0, -1, 0, 0],  # weight_total_earliness < 0
         [0, 0, 0, 0, 0, -1, 0],  # weight_max_tardiness < 0
-        [0, 0, 0, 0, 0, 0, -1],  # weight_total_setup_time < 0
+        [0, 0, 0, 0, 0, 0, -1, 0],  # weight_total_setup_time < 0
+        [0, 0, 0, 0, 0, 0, 0, -1],  # weight_max_earliness < 0
     ],
 )
 def test_objective_valid_values(weights: list[int]):
@@ -824,6 +825,7 @@ def test_problem_data_raises_mode_dependency_same_task():
         Objective(weight_total_tardiness=1),
         Objective(weight_total_earliness=1),
         Objective(weight_max_tardiness=1),
+        Objective(weight_max_earliness=1),
     ],
 )
 def test_problem_data_tardy_objective_without_job_due_dates(
@@ -2522,6 +2524,31 @@ def test_max_tardiness(solver: str):
     # Both jobs are tardy by 2 time units, but job 1 has weight 2 and job 2
     # has weight 1. So the maximum tardiness is 2 * 2 = 4. Multiplied with the
     # ``weight_max_tardiness`` of 2, the objective value is 8.
+    assert_equal(result.objective, 8)
+    assert_equal(result.best.tasks[0].end, 2)
+    assert_equal(result.best.tasks[1].end, 2)
+
+
+def test_max_earliness(solver: str):
+    """
+    Tests that the maximum earliness objective function is correctly optimized.
+    """
+    model = Model()
+
+    for idx in range(2):
+        machine = model.add_machine()
+        job = model.add_job(weight=idx + 1, deadline=2, due_date=4)
+        task = model.add_task(job=job)
+        model.add_mode(task, machine, duration=2)
+
+    model.set_objective(weight_max_earliness=2)
+
+    result = model.solve(solver=solver)
+
+    # Both jobs must finish by their deadline at time 2, which is 2 time units
+    # before their due date. Job 1 has weight 2 and job 2 has weight 1. So the
+    # maximum earliness is 2 * 2 = 4. Multiplied with the
+    # ``weight_max_earliness`` of 2, the objective value is 8.
     assert_equal(result.objective, 8)
     assert_equal(result.best.tasks[0].end, 2)
     assert_equal(result.best.tasks[1].end, 2)

--- a/tests/test_Solution.py
+++ b/tests/test_Solution.py
@@ -109,6 +109,7 @@ def test_solution_empty(small):
     assert_equal(sol.total_tardiness, 0)
     assert_equal(sol.total_earliness, 0)
     assert_equal(sol.max_tardiness, 0)
+    assert_equal(sol.max_earliness, 0)
     assert_equal(sol.total_setup_time, 0)
     assert_equal(sol.objective, 0)
 
@@ -215,7 +216,7 @@ def test_solution_objective_components():
         tasks=tasks,
         modes=modes,
         resources=[Machine()],
-        objective=Objective(2, 2, 2, 2, 2, 2, 0),
+        objective=Objective(2, 2, 2, 2, 2, 2, 0, 2),
     )
 
     task_data = [
@@ -230,9 +231,10 @@ def test_solution_objective_components():
     assert_equal(solution.total_tardiness, 3)  # 3*1 + 1*0 = 3
     assert_equal(solution.total_earliness, 2)  # 3*0 + 1*2 = 2
     assert_equal(solution.max_tardiness, 3)  # max(3*1, 1*0) = 3
+    assert_equal(solution.max_earliness, 2)  # max(3*0, 1*2) = 2
     assert_equal(solution.total_setup_time, 0)
 
-    assert_equal(solution.objective, 52)
+    assert_equal(solution.objective, 56)
 
 
 def test_solution_total_setup_time():


### PR DESCRIPTION
This PR:

- [x] Closes #444.
- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

Adds `weight_max_earliness` as max_j w_j * max(d_j - C_j, 0), using the same code paths as `weight_max_tardiness`.

Tested locally with `uv run pytest --solvers ortools --ignore=tests/plot` and `uv run pre-commit run --all-files`.
